### PR TITLE
Added fix for RiME

### DIFF
--- a/protonfixes/gamefixes/493200.py
+++ b/protonfixes/gamefixes/493200.py
@@ -1,0 +1,28 @@
+""" Game fix for RiME
+"""
+
+# pylint: disable=C0103
+
+from protonfixes import util
+
+
+def main():
+    """ Install xact and dinput8, override libraries and disable esync
+    """
+
+    print('Applying fixes for RiME')
+
+    # If not already installed, install xact
+    if not util.checkinstalled('xact'):
+        util.protontricks('xact')
+
+    # Gamepad doesn't work properly without dinput8 installed
+    if not util.checkinstalled('dinput8'):
+        util.protontricks('dinput8')
+
+    # To fix audio crackling, set xaudio2_7.dll to native
+    # To fix gamepad set dinput8 to native
+    util.winedll_override('xaudio2_7,dinput8', 'n')
+
+    # disable esync to prevent game crash after a few minutes
+    util.disable_esync()


### PR DESCRIPTION
RiME needs several fixes to work properly:

1. `xact` installed and `xaudio2_7` set to native to fix crackling audio
1. `dinput8` installed and `dinput8` set to native to fix broken gamepad support
1. disable `esync` to prevent the game from crashing after a few minutes