### PR TITLE
Rising Storm/Red Orchestra 2 Multiplayer (35450)

### DIFF
--- a/protonfixes/gamefixes/35450.py
+++ b/protonfixes/gamefixes/35450.py
@@ -1,0 +1,16 @@
+""" Game fix for Rising Storm/Red Orchestra 2 Multiplayer
+"""
+# pylint: disable=C0103
+from protonfixes import util
+
+
+def main():
+    """ Install xact
+    """
+
+    print('Applying fixes for Rising Storm/Red Orchestra 2 Multiplayer')
+
+    # Unreal Engine games needs xact, otherwise all audio will be playing at equal loudness.
+    # https://github.com/ValveSoftware/Proton/issues/54
+    # https://github.com/ValveSoftware/Proton/issues/155
+    util.protontricks('xact')


### PR DESCRIPTION
Added audio fix (install xact from winetricks) for Rising Storm/Red Orchestra 2 Multiplayer (Unreal Engine 3 game) based on the Spacewar fix, probably can be applied to other UE3 games with similar problems.