### PR TITLE
Added custom winetricks verbs support

### DIFF
--- a/protonfixes/gamefixes/verbs/force_gpu.verb
+++ b/protonfixes/gamefixes/verbs/force_gpu.verb
@@ -1,0 +1,33 @@
+w_metadata force_gpu=amd settings \
+    title="Fake an AMD RADEON RX 480 card in place of Nvidia cards (default)"
+w_metadata force_gpu=nvidia settings \
+    title="Force Nvidia GeForce GTX 970 card"
+w_metadata force_gpu=no settings \
+    title="Use WINE/Proton defaults for GPU"
+
+load_force_gpu()
+{
+    # Both cards are from dlls/wined3d/adapter_gl.c
+    # cards_amd_mesa[] / cards_nvidia_mesa[] list
+    # most top in the list
+    case "$arg" in
+        amd) _W_gpu_vendor="dword:00001002"; _W_gpu_device="dword:000067df";;
+        nvidia) _W_gpu_vendor="dword:000010de"; _W_gpu_device="dword:000013c2";;
+        no) _W_gpu_vendor="-"; _W_gpu_device="-";;
+        *) w_die "Unexpected argument '$arg'. Should be default/amd/nvidia";;
+    esac
+
+    echo "Forcing GPU to '$arg'"
+    cat > "$W_TMP"/force_gpu.reg <<_EOF_
+REGEDIT4
+
+[HKEY_CURRENT_USER\\Software\\Wine\\Direct3D]
+"VideoPciVendorID"=${_W_gpu_vendor}
+"VideoPciDeviceID"=${_W_gpu_device}
+_EOF_
+
+    w_try_regedit "$W_TMP_WIN"\\force_gpu.reg
+
+    unset _W_gpu_vendor
+    unset _W_gpu_device
+}

--- a/protonfixes/gamefixes/verbs/force_gpu=amd.verb
+++ b/protonfixes/gamefixes/verbs/force_gpu=amd.verb
@@ -1,0 +1,1 @@
+force_gpu.verb

--- a/protonfixes/gamefixes/verbs/force_gpu=no.verb
+++ b/protonfixes/gamefixes/verbs/force_gpu=no.verb
@@ -1,0 +1,1 @@
+force_gpu.verb

--- a/protonfixes/gamefixes/verbs/force_gpu=nvidia.verb
+++ b/protonfixes/gamefixes/verbs/force_gpu=nvidia.verb
@@ -1,0 +1,1 @@
+force_gpu.verb

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -115,6 +115,28 @@ def checkinstalled(verb):
     return False
 
 
+def is_custom_verb(verb):
+    """ Returns path to custom winetricks verb, if found
+    """
+
+    verb_name = verb + '.verb'
+    verb_dir = 'verbs'
+
+    # check local custom verbs
+    verbpath = os.path.expanduser('~/.config/protonfixes/localfixes/' + verb_dir)
+    if os.path.isfile(os.path.join(verbpath, verb_name)):
+        log.debug('Using local custom winetricks verb from: ' + verbpath)
+        return os.path.join(verbpath, verb_name)
+
+    # check custom verbs
+    verbpath = os.path.join(os.path.dirname(__file__), 'gamefixes', verb_dir)
+    if os.path.isfile(os.path.join(verbpath, verb_name)):
+        log.debug('Using custom winetricks verb from: ' + verbpath)
+        return os.path.join(verbpath, verb_name)
+
+    return False
+
+
 def protontricks(verb):
     """ Runs winetricks if available
     """
@@ -131,6 +153,11 @@ def protontricks(verb):
 
         winetricks_bin = which('winetricks')
         winetricks_cmd = [winetricks_bin, '--unattended'] + verb.split(' ')
+
+        # check is verb a custom winetricks verb
+        custom_verb = is_custom_verb(verb)
+        if custom_verb:
+            winetricks_cmd = [winetricks_bin, '--unattended', custom_verb]
 
         if winetricks_bin is None:
             log.warn('No winetricks was found in $PATH')


### PR DESCRIPTION
* Custom winetricks verbs support
  Partially resolves simons-public#41 
  ` util.protontricks('winetricks_verb')` will search for a `$winetricks_verb$.verb` file in
  * localfixes/verbs/ - local custom verbs
  * gamefixes/verbs/ - builtin custom verbs

* Custom winetricks verb example
  This will force AMD or Nvidia GPU via registry
  Example:
  ```
  util.protontricks('force_gpu=nvidia')
  ```
  Supported variants:
  `force_gpu=amd`, `force_gpu=nvidia` and `force_gpu=no`