### PR TITLE
Possible fix for a rare winetricks fail

### DIFF
--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -178,7 +178,7 @@ def protontricks(verb):
                     log.debug(str(sys.argv))
 
             log.info('Using winetricks verb ' + verb)
-            subprocess.call(['wineserver', '-w'], env=env)
+            subprocess.call([env['WINESERVER'], '-w'], env=env)
             process = subprocess.Popen(winetricks_cmd, env=env)
             process.wait()
             _killhanging()

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -178,6 +178,7 @@ def protontricks(verb):
                     log.debug(str(sys.argv))
 
             log.info('Using winetricks verb ' + verb)
+            subprocess.call(['wineserver', '-w'], env=env)
             process = subprocess.Popen(winetricks_cmd, env=env)
             process.wait()
             _killhanging()


### PR DESCRIPTION
Sometimes `winetricks` performs a strange things, so
very likely it should wait for `wineserver` to quit.

Not sure, but it can also help #19, or otherwise there
should be one more check for a prefix existence.