### PR TITLE
Added a proper check for `verb=param` verb types

### DIFF
--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -106,6 +106,24 @@ def checkinstalled(verb):
 
     log.info('Checking if winetricks ' + verb + ' is installed')
     winetricks_log = os.path.join(protonprefix(), 'winetricks.log')
+
+    # Check for 'verb=param' verb types
+    if len(verb.split('=')) > 1:
+        wt_verb = verb.split('=')[0] + '='
+        wt_verb_param = verb.split('=')[1]
+        wt_is_set = False
+        try:
+            with open(winetricks_log, 'r') as tricklog:
+                for xline in tricklog.readlines():
+                    if re.findall(r'^' + wt_verb, xline.strip()):
+                        if xline.strip() == wt_verb + wt_verb_param:
+                            wt_is_set = True
+                        else:
+                            wt_is_set = False
+            return wt_is_set
+        except OSError:
+            return False
+    # Check for regular verbs
     try:
         with open(winetricks_log, 'r') as tricklog:
             if verb in reversed([x.strip() for x in tricklog.readlines()]):


### PR DESCRIPTION
Such verbs are usually recorded into `winetricks.log` as:
```
verb1=param1
verb1=param2
verb1=param1
```
In this example `verb1=param1` should be "INSTALLED",
and `verb1=param2` -- "NOT INSTALLED", so will be applied and
recorded to `winetricks.log` (appended at the end of file).