### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you want to use a win32 (32bit) prefix, you need to have wine installed and b
 
 **Progress Dialog / Splashscreen**
 
-If Steam is in big picture mode, protontricks will try to launch a similarly themed splash dialog using `cefpython` (pictured above). Otherwise it will try to use `zenity` to display a progress bar. If Steam is not in big picture mode, it will default to `zenity`. The progress bar or splashscreen can help let you know that protonfixes is running a long task, for example installing `dotnet35`.
+If Steam is in big picture mode, protonfixes will try to launch a similarly themed splash dialog using `cefpython` (pictured above). Otherwise it will try to use `zenity` to display a progress bar. If Steam is not in big picture mode, it will default to `zenity`. The progress bar or splashscreen can help let you know that protonfixes is running a long task, for example installing `dotnet35`.
 
 For the progress dialog to work, you need to have `zenity` installed on your system, the steam-runtime version is broken. It can probably be installed using your distro's package manager.
 


### PR DESCRIPTION
Fixes a typo under the *Progress Dialog / Splashscreen* section, replacing "Protontricks" with "Protonfixes"