### PR TITLE
Fixed non-strict INI files parsing

### DIFF
--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -427,7 +427,7 @@ def set_ini_options(ini_opts, cfile, base_path='user'):
         log.info('Creating backup for INI file')
         shutil.copyfile(cfg_path, cfg_path + '.protonfixes.bak')
 
-    conf = configparser.ConfigParser()
+    conf = configparser.ConfigParser(empty_lines_in_values=True, allow_no_value=True, strict=False)
     conf.optionxform = str
 
     conf.read(cfg_path)


### PR DESCRIPTION
* duplicate variables in section
    ```ini
    var1=val1
    var2=val2
    var1=
    ```
* multiline values
    ```ini
    var1=Hello,
    World
     var2=val2
    ```