### PR TITLE
Added fix for Portal Knights

### DIFF
--- a/protonfixes/gamefixes/374040.py
+++ b/protonfixes/gamefixes/374040.py
@@ -1,0 +1,14 @@
+from protonfixes import util
+
+
+def main():
+    """ Install xact and override xaudio2_7 to native
+    """
+
+    print('Applying fixes for Portal Knights')
+
+    # install xact
+    util.protontricks('xact')
+
+    # set xaudio2_7.dll to native
+    util.winedll_override('xaudio2_7', 'n')


### PR DESCRIPTION
Portal Knights needs `xact` installed and `xaudio2_7` set to native. Otherwise there is no audio.