### PR TITLE
Return Proton version timestamp

### DIFF
--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -49,7 +49,7 @@ def protonprefix():
         'pfx/')
 
 
-def protonversion():
+def protonnameversion():
     """ Returns the version of proton from sys.argv[0]
     """
 
@@ -58,6 +58,28 @@ def protonversion():
         return version.group(1)
     log.warn('Proton version not parsed from command line')
     return None
+
+
+def protontimeversion():
+    """ Returns the version timestamp of proton from the `version` file
+    """
+
+    fullpath = os.path.join(protondir(), 'version')
+    try:
+        with open(fullpath, 'r') as version:
+            for timestamp in version.readlines():
+                return timestamp.strip()
+    except OSError:
+        log.warn('Proton version file not found in: ' + fullpath)
+        return 0
+    log.warn('Proton version not parsed from file: ' + fullpath)
+    return 0
+
+
+def protonversion(timestamp=False):
+    if timestamp:
+        return protontimeversion()
+    return protonnameversion()
 
 
 def _killhanging():

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -77,6 +77,9 @@ def protontimeversion():
 
 
 def protonversion(timestamp=False):
+    """ Returns the version of proton
+    """
+
     if timestamp:
         return protontimeversion()
     return protonnameversion()


### PR DESCRIPTION
`util.protonversion()` currently returns the version name (e.g. `Proton 3.16`)
`util.protonversion(True)` will return the version timestamp (e.g. `1544476838`)

Resolves: #63