### PR TITLE
Return Proton version timestamp as int not str

### DIFF
--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -68,7 +68,7 @@ def protontimeversion():
     try:
         with open(fullpath, 'r') as version:
             for timestamp in version.readlines():
-                return timestamp.strip()
+                return int(timestamp.strip())
     except OSError:
         log.warn('Proton version file not found in: ' + fullpath)
         return 0


### PR DESCRIPTION
The new proton version timestamp added in #65 is being returned as `str`. This should `int` instead. 