### PR TITLE
Only use xact fix if Proton version prior 3.16-5 (424840, 493200)

### DIFF
--- a/protonfixes/gamefixes/424840.py
+++ b/protonfixes/gamefixes/424840.py
@@ -5,15 +5,18 @@
 import sys
 from protonfixes import util
 
+
 def main():
     """ Install xact, override libraries and add launch parameter
     """
 
-    # If not already installed, install xact
-    util.protontricks('xact')
+    # If proton Version is older than 3.16-5
+    if util.protonversion(True) < 1544476838:
+        # If not already installed, install xact
+        util.protontricks('xact')
 
-    # To fix audio crackling, set xaudio2_6.dll and xaudio2_7.dll to native
-    util.winedll_override('xaudio2_6,xaudio2_7', 'n')
+        # To fix audio crackling, set xaudio2_6.dll and xaudio2_7.dll to native
+        util.winedll_override('xaudio2_6,xaudio2_7', 'n')
 
     # The game crashes if running with more than one CPU thread,
     # adding "-onethread" will force the game to use only one CPU thread

--- a/protonfixes/gamefixes/493200.py
+++ b/protonfixes/gamefixes/493200.py
@@ -12,17 +12,19 @@ def main():
 
     print('Applying fixes for RiME')
 
-    # If not already installed, install xact
-    if not util.checkinstalled('xact'):
+    # if Proton version older than 3.16-5
+    if util.protonversion(True) < 1544476838:
+        # If not already installed, install xact
         util.protontricks('xact')
 
-    # Gamepad doesn't work properly without dinput8 installed
-    if not util.checkinstalled('dinput8'):
-        util.protontricks('dinput8')
+        # To fix audio crackling, set xaudio2_7.dll to native
+        util.winedll_override('xaudio2_7', 'n')
 
-    # To fix audio crackling, set xaudio2_7.dll to native
+    # Gamepad doesn't work properly without dinput8 installed
+    util.protontricks('dinput8')
+
     # To fix gamepad set dinput8 to native
-    util.winedll_override('xaudio2_7,dinput8', 'n')
+    util.winedll_override('dinput8', 'n')
 
     # disable esync to prevent game crash after a few minutes
     util.disable_esync()


### PR DESCRIPTION
With FAudio the xact audio is not needed anymore for many games. This updates the fixes for Little Nightmares and RiME to only be applied if used Proton version is older than 3.16-5.