### PR TITLE
Added fixes for 200260 211420 220440 268910 35140

### DIFF
--- a/protonfixes/gamefixes/200260.py
+++ b/protonfixes/gamefixes/200260.py
@@ -1,0 +1,18 @@
+""" Game fix Batman Arkham City
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    #Probably not needed when proton will be merged with newer wine
+    util.use_win32_prefix() 
+    util.protontricks('dotnet20')
+    util.protontricks('dotnet35')
+    util.protontricks('physx')
+    util.protontricks('mdx')
+    util.protontricks('d3dcompiler_43')
+    util.protontricks('d3dx9_43')
+    util.protontricks('win10')
+    util._mk_syswow64()
+#TODO Checking possibly some tweak for language detection

--- a/protonfixes/gamefixes/211420.py
+++ b/protonfixes/gamefixes/211420.py
@@ -1,0 +1,23 @@
+""" Game fix Dark Sould Prepare To Die Edition
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    #For WMP9 to work
+    util.use_win32_prefix()
+    
+    #For main menu, intro and outro playback
+    util.protontricks('wmp9')
+    util.protontricks('devenum')
+    util.protontricks('quartz')
+
+    #In case if someone wishes to use DSfix
+    util.protontricks('dinput8')
+    util.winedll_override('dinput8', 'n')
+
+    util.protontricks('win7')
+    #Avoiding problems with missing syswow64
+    util._mk_syswow64()
+

--- a/protonfixes/gamefixes/220440.py
+++ b/protonfixes/gamefixes/220440.py
@@ -1,0 +1,12 @@
+""" Game fix DMC Devil May Cry
+    (Currently without controller)
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    util.use_win32_prefix()
+    util.protontricks('dotnet40')
+    util._mk_syswow64()
+#TODO Controllers fixes

--- a/protonfixes/gamefixes/268910.py
+++ b/protonfixes/gamefixes/268910.py
@@ -1,0 +1,10 @@
+""" Game fix Cuphead
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    #For some systems using 64 bit prefix may cause data.unity3d not found error
+    util.use_win32_prefix()
+

--- a/protonfixes/gamefixes/35140.py
+++ b/protonfixes/gamefixes/35140.py
@@ -1,0 +1,19 @@
+""" Game fix Batman Arkham Asylum
+    (Currently no contollers)
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    #Probably not needed when proton will be merged with newer wine
+    util.use_win32_prefix()
+    util.protontricks('winxp')
+    util.protontricks('dotnet20')
+    util.protontricks('dotnet35')
+    util.protontricks('physx')
+    util.protontricks('mdx')
+    util.protontricks('d3dx9')
+    util.protontricks('d3dcompiler_43')
+    util._mk_syswow64()
+#TODO Controllers fixes 


### PR DESCRIPTION
Fixed:
Cuphead - data.unity3d missing errors on some configuration
Batman Arkham City - fully working in DX9, except finding correct locales.
Batman Arkham Asylum - working, but needs controller fix
DMC: Devil May Cry - working, but needs controller fix
Dark Souls: Prepare To Die Edition - working, fixed cinematics, 