### PR TITLE
Fix for divinity original sin 2

### DIFF
--- a/protonfixes/gamefixes/435150.py
+++ b/protonfixes/gamefixes/435150.py
@@ -1,0 +1,34 @@
+""" Game fix for Divinity Original Sin 2
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes import splash
+import os
+import shutil
+import subprocess
+
+
+def main():
+    """ Launcherfix
+    """
+
+    installpath = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
+    oldbin = os.getcwd()
+    oldbinbak = os.path.join(os.path.abspath(installpath), 'bin.bak')
+    newbin = os.path.join(os.path.abspath(installpath), 'DefEd', 'bin')
+
+    if not os.path.isfile(os.path.join(os.path.abspath(installpath), 'bin', 'EoCApp.exe')):
+        shutil.move(oldbin, oldbinbak)
+        subprocess.call(['ln', '-s', newbin, oldbin])
+        zenity_bin = splash.sys_zenity_path()
+        if not zenity_bin:
+            return
+        zenity_cmd = ' '.join([zenity_bin, '--info','--text', '"Steam Play symlinks for Divinity: Original Sin 2 have been set. On first launch the game will black screen. Please force it to close then press PLAY again."', '--no-wrap'])
+        zenity = subprocess.Popen(zenity_cmd, shell=True)
+
+    util.replace_command('SupportTool.exe', 'EoCApp.exe')
+
+
+
+


### PR DESCRIPTION
Divinity OS 2 is a finnicky thing. It requires backing up the existing bin folder, then symlinking the bin folder from DefEd/ to the root game directory. This of course results in getting reset every update.  Additionally, after the symlink, on first launch the game will give a black screen. On subsequent launches the game runs fine.

The patch I've added makes the proper symlink only if EoCApp.exe is not detected in the /bin folder, as it doesn't exist in the original bin folder.  It will additionally give the user a prompt to let them know on first run the game will black screen, and that they must close and re-launch the game.

As mentioned, after this is done once, the script just runs the game accordingly until the next time an update resets the symlinks, in which case it performs the actions again.

I've additionally integrated protonfixes as part of my proton build that I update regularly, found here:
https://github.com/gloriouseggroll/proton-ge-custom