### PR TITLE
fixes for batman arkham city and asylum, fix for strange brigade

### DIFF
--- a/protonfixes/gamefixes/200260.py
+++ b/protonfixes/gamefixes/200260.py
@@ -7,7 +7,6 @@ from protonfixes import util
 def main():
     """ Probably not needed when proton will be merged with newer wine
     """
-    util.use_win32_prefix()
     util.protontricks('dotnet20')
     util.protontricks('dotnet35')
     util.protontricks('physx')

--- a/protonfixes/gamefixes/312670.py
+++ b/protonfixes/gamefixes/312670.py
@@ -1,0 +1,14 @@
+""" Game fix for Strange Brigade
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ This bypasses Strange Brigade's Launcher, which renders all black.
+    """
+
+    # Fixes the startup process.
+    util.replace_command('StrangeBrigade.exe', 'StrangeBrigade_Vulkan.exe')
+    util.append_argument('-skipdrivercheck -noHDR')
+

--- a/protonfixes/gamefixes/35140.py
+++ b/protonfixes/gamefixes/35140.py
@@ -9,14 +9,13 @@ def main():
     """ Needs windxp, dotnet35, phyzx, d3dx9 """
 
     #Probably not needed when proton will be merged with newer wine
-    util.use_win32_prefix()
-    util.protontricks('winxp')
     util.protontricks('dotnet20')
     util.protontricks('dotnet35')
     util.protontricks('physx')
     util.protontricks('mdx')
-    util.protontricks('d3dx9')
     util.protontricks('d3dcompiler_43')
+    util.protontricks('d3dx9_43')
+    util.protontricks('win10')
     util._mk_syswow64() #pylint: disable=protected-access
 
 #TODO Controllers fixes


### PR DESCRIPTION
Batman Arkham City and Arkham Asylum don't need 32 bit prefixes any more, also they use the exact same dependencies. The corrections in this commit allow them to work OOTB including the launchers for both.

The Strange Brigade launcher renders all black. The script provided skips the launcher altogether and launches the Vulkan version of the game with the default launch options as if run by the launcher.