### PR TITLE
[util] Fix disable_d9vk and add disable_fsync

### DIFF
--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -394,7 +394,7 @@ def disable_d3d10():
     winedll_override('d3d10_1', '')
     winedll_override('d3d10core', '')
 
-def disable_d9vk():  # pylint: disable=missing-docstring
+def enable_d9vk():  # pylint: disable=missing-docstring
     set_environment('PROTON_USE_D9VK', '1')
 
 def disable_dxvk():  # pylint: disable=missing-docstring
@@ -403,6 +403,9 @@ def disable_dxvk():  # pylint: disable=missing-docstring
 def disable_esync():  # pylint: disable=missing-docstring
     set_environment('PROTON_NO_ESYNC', '1')
 
+def disable_fsync(): # pylint: disable=missing-docstring
+    set_environment('PROTON_NO_FSYNC', '1')
+    
 def disable_d3d11():  # pylint: disable=missing-docstring
     set_environment('PROTON_NO_D3D11', '1')
 

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -405,7 +405,7 @@ def disable_esync():  # pylint: disable=missing-docstring
 
 def disable_fsync(): # pylint: disable=missing-docstring
     set_environment('PROTON_NO_FSYNC', '1')
-    
+
 def disable_d3d11():  # pylint: disable=missing-docstring
     set_environment('PROTON_NO_D3D11', '1')
 


### PR DESCRIPTION
D9VK is disabled by default (because is a experimental translation layer) and disable_fsync is added (Proton 4.11 or above).