### PR TITLE
Needs Testing: Use one ManiaPlanet folder for all ManiaPlanet games

### DIFF
--- a/protonfixes/gamefixes/228760.py
+++ b/protonfixes/gamefixes/228760.py
@@ -1,33 +1,35 @@
-""" Game fix for TrackMania2 Canyon
+""" Game fix for TrackMania² Canyon
 """
 #pylint: disable=C0103
 
+import os
 from protonfixes import util
 from protonfixes.logger import log
-import os
 
-mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+mania_planet_games = [264850, 228760, 232910, 243360, 264660,
+                      600720, 600730, 233070, 229870, 233050]
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+        With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
-    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
-    compdata_folder = os.path.dirname( game_proton_bottle )
-    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+    game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
+    compdata_folder = os.path.dirname(game_proton_bottle)
+    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists( mania_planet_folder ):
-        log( "Could not find ManiaPlanet directory." )
-        log( "Creating new folder and symlinking Games to it." )
-        os.rename( game_proton_bottle , mania_planet_folder )
-        os.symlink( mania_planet_folder, game_proton_bottle)
+    if not os.path.exists(mania_planet_folder):
+        log("Could not find ManiaPlanet directory.")
+        log("Creating new folder and symlinking Games to it.")
+        os.rename(game_proton_bottle, mania_planet_folder)
+        os.symlink(mania_planet_folder, game_proton_bottle)
 
         for game_id in mania_planet_games:
-            game_path = os.path.join( compdata_folder, str(game_id) )
+            game_path = os.path.join(compdata_folder, str(game_id))
             if game_path == game_proton_bottle:
                 continue
-            if os.path.exists( game_path ):
-                os.remove( game_id )
+            if os.path.exists(game_path):
+                os.remove(game_id)
 
-            os.symlink( mania_planet_folder, game_path )
-        log( "All DONE" )
+            os.symlink(mania_planet_folder, game_path)
+        log("All DONE")

--- a/protonfixes/gamefixes/228760.py
+++ b/protonfixes/gamefixes/228760.py
@@ -1,0 +1,33 @@
+""" Game fix for TrackMania2 Canyon
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+import os
+
+mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+
+def main():
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """
+
+    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
+    compdata_folder = os.path.dirname( game_proton_bottle )
+    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+
+    if not os.path.exists( mania_planet_folder ):
+        log( "Could not find ManiaPlanet directory." )
+        log( "Creating new folder and symlinking Games to it." )
+        os.rename( game_proton_bottle , mania_planet_folder )
+        os.symlink( mania_planet_folder, game_proton_bottle)
+
+        for game_id in mania_planet_games:
+            game_path = os.path.join( compdata_folder, str(game_id) )
+            if game_path == game_proton_bottle:
+                continue
+            if os.path.exists( game_path ):
+                os.remove( game_id )
+
+            os.symlink( mania_planet_folder, game_path )
+        log( "All DONE" )

--- a/protonfixes/gamefixes/229870.py
+++ b/protonfixes/gamefixes/229870.py
@@ -1,4 +1,4 @@
-""" Game fix for TrackMania² Stadium
+""" Game fix for ShootMania Storm
 """
 #pylint: disable=C0103
 

--- a/protonfixes/gamefixes/232910.py
+++ b/protonfixes/gamefixes/232910.py
@@ -1,0 +1,33 @@
+""" Game fix for TrackMania2 Stadium
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+import os
+
+mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+
+def main():
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """
+
+    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
+    compdata_folder = os.path.dirname( game_proton_bottle )
+    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+
+    if not os.path.exists( mania_planet_folder ):
+        log( "Could not find ManiaPlanet directory." )
+        log( "Creating new folder and symlinking Games to it." )
+        os.rename( game_proton_bottle , mania_planet_folder )
+        os.symlink( mania_planet_folder, game_proton_bottle)
+
+        for game_id in mania_planet_games:
+            game_path = os.path.join( compdata_folder, str(game_id) )
+            if game_path == game_proton_bottle:
+                continue
+            if os.path.exists( game_path ):
+                os.remove( game_id )
+
+            os.symlink( mania_planet_folder, game_path )
+        log( "All DONE" )

--- a/protonfixes/gamefixes/233050.py
+++ b/protonfixes/gamefixes/233050.py
@@ -1,4 +1,4 @@
-""" Game fix for TrackMania² Stadium
+""" Game fix for ShootMania Storm Demo
 """
 #pylint: disable=C0103
 

--- a/protonfixes/gamefixes/233070.py
+++ b/protonfixes/gamefixes/233070.py
@@ -1,0 +1,33 @@
+""" Game fix for FINAL TrackMania2 Stadium Demo
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+import os
+
+mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+
+def main():
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """
+
+    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
+    compdata_folder = os.path.dirname( game_proton_bottle )
+    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+
+    if not os.path.exists( mania_planet_folder ):
+        log( "Could not find ManiaPlanet directory." )
+        log( "Creating new folder and symlinking Games to it." )
+        os.rename( game_proton_bottle , mania_planet_folder )
+        os.symlink( mania_planet_folder, game_proton_bottle)
+
+        for game_id in mania_planet_games:
+            game_path = os.path.join( compdata_folder, str(game_id) )
+            if game_path == game_proton_bottle:
+                continue
+            if os.path.exists( game_path ):
+                os.remove( game_id )
+
+            os.symlink( mania_planet_folder, game_path )
+        log( "All DONE" )

--- a/protonfixes/gamefixes/233070.py
+++ b/protonfixes/gamefixes/233070.py
@@ -1,33 +1,35 @@
-""" Game fix for FINAL TrackMania2 Stadium Demo
+""" Game fix for TrackMania² Stadium Demo
 """
 #pylint: disable=C0103
 
+import os
 from protonfixes import util
 from protonfixes.logger import log
-import os
 
-mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+mania_planet_games = [264850, 228760, 232910, 243360, 264660,
+                      600720, 600730, 233070, 229870, 233050]
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+        With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
-    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
-    compdata_folder = os.path.dirname( game_proton_bottle )
-    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+    game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
+    compdata_folder = os.path.dirname(game_proton_bottle)
+    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists( mania_planet_folder ):
-        log( "Could not find ManiaPlanet directory." )
-        log( "Creating new folder and symlinking Games to it." )
-        os.rename( game_proton_bottle , mania_planet_folder )
-        os.symlink( mania_planet_folder, game_proton_bottle)
+    if not os.path.exists(mania_planet_folder):
+        log("Could not find ManiaPlanet directory.")
+        log("Creating new folder and symlinking Games to it.")
+        os.rename(game_proton_bottle, mania_planet_folder)
+        os.symlink(mania_planet_folder, game_proton_bottle)
 
         for game_id in mania_planet_games:
-            game_path = os.path.join( compdata_folder, str(game_id) )
+            game_path = os.path.join(compdata_folder, str(game_id))
             if game_path == game_proton_bottle:
                 continue
-            if os.path.exists( game_path ):
-                os.remove( game_id )
+            if os.path.exists(game_path):
+                os.remove(game_id)
 
-            os.symlink( mania_planet_folder, game_path )
-        log( "All DONE" )
+            os.symlink(mania_planet_folder, game_path)
+        log("All DONE")

--- a/protonfixes/gamefixes/243360.py
+++ b/protonfixes/gamefixes/243360.py
@@ -1,33 +1,35 @@
-""" Game fix for TrackMania2 Valley
+""" Game fix for TrackMania² Valley
 """
 #pylint: disable=C0103
 
+import os
 from protonfixes import util
 from protonfixes.logger import log
-import os
 
-mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+mania_planet_games = [264850, 228760, 232910, 243360, 264660,
+                      600720, 600730, 233070, 229870, 233050]
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+        With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
-    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
-    compdata_folder = os.path.dirname( game_proton_bottle )
-    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+    game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
+    compdata_folder = os.path.dirname(game_proton_bottle)
+    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists( mania_planet_folder ):
-        log( "Could not find ManiaPlanet directory." )
-        log( "Creating new folder and symlinking Games to it." )
-        os.rename( game_proton_bottle , mania_planet_folder )
-        os.symlink( mania_planet_folder, game_proton_bottle)
+    if not os.path.exists(mania_planet_folder):
+        log("Could not find ManiaPlanet directory.")
+        log("Creating new folder and symlinking Games to it.")
+        os.rename(game_proton_bottle, mania_planet_folder)
+        os.symlink(mania_planet_folder, game_proton_bottle)
 
         for game_id in mania_planet_games:
-            game_path = os.path.join( compdata_folder, str(game_id) )
+            game_path = os.path.join(compdata_folder, str(game_id))
             if game_path == game_proton_bottle:
                 continue
-            if os.path.exists( game_path ):
-                os.remove( game_id )
+            if os.path.exists(game_path):
+                os.remove(game_id)
 
-            os.symlink( mania_planet_folder, game_path )
-        log( "All DONE" )
+            os.symlink(mania_planet_folder, game_path)
+        log("All DONE")

--- a/protonfixes/gamefixes/243360.py
+++ b/protonfixes/gamefixes/243360.py
@@ -1,0 +1,33 @@
+""" Game fix for TrackMania2 Valley
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+import os
+
+mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+
+def main():
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """
+
+    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
+    compdata_folder = os.path.dirname( game_proton_bottle )
+    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+
+    if not os.path.exists( mania_planet_folder ):
+        log( "Could not find ManiaPlanet directory." )
+        log( "Creating new folder and symlinking Games to it." )
+        os.rename( game_proton_bottle , mania_planet_folder )
+        os.symlink( mania_planet_folder, game_proton_bottle)
+
+        for game_id in mania_planet_games:
+            game_path = os.path.join( compdata_folder, str(game_id) )
+            if game_path == game_proton_bottle:
+                continue
+            if os.path.exists( game_path ):
+                os.remove( game_id )
+
+            os.symlink( mania_planet_folder, game_path )
+        log( "All DONE" )

--- a/protonfixes/gamefixes/264660.py
+++ b/protonfixes/gamefixes/264660.py
@@ -1,33 +1,35 @@
-""" Game fix for TrackMania2 Valley Demo
+""" Game fix for TrackMania² Valley Demo
 """
 #pylint: disable=C0103
 
+import os
 from protonfixes import util
 from protonfixes.logger import log
-import os
 
-mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+mania_planet_games = [264850, 228760, 232910, 243360, 264660,
+                      600720, 600730, 233070, 229870, 233050]
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+        With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
-    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
-    compdata_folder = os.path.dirname( game_proton_bottle )
-    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+    game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
+    compdata_folder = os.path.dirname(game_proton_bottle)
+    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists( mania_planet_folder ):
-        log( "Could not find ManiaPlanet directory." )
-        log( "Creating new folder and symlinking Games to it." )
-        os.rename( game_proton_bottle , mania_planet_folder )
-        os.symlink( mania_planet_folder, game_proton_bottle)
+    if not os.path.exists(mania_planet_folder):
+        log("Could not find ManiaPlanet directory.")
+        log("Creating new folder and symlinking Games to it.")
+        os.rename(game_proton_bottle, mania_planet_folder)
+        os.symlink(mania_planet_folder, game_proton_bottle)
 
         for game_id in mania_planet_games:
-            game_path = os.path.join( compdata_folder, str(game_id) )
+            game_path = os.path.join(compdata_folder, str(game_id))
             if game_path == game_proton_bottle:
                 continue
-            if os.path.exists( game_path ):
-                os.remove( game_id )
+            if os.path.exists(game_path):
+                os.remove(game_id)
 
-            os.symlink( mania_planet_folder, game_path )
-        log( "All DONE" )
+            os.symlink(mania_planet_folder, game_path)
+        log("All DONE")

--- a/protonfixes/gamefixes/264660.py
+++ b/protonfixes/gamefixes/264660.py
@@ -1,0 +1,33 @@
+""" Game fix for TrackMania2 Valley Demo
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+import os
+
+mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+
+def main():
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """
+
+    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
+    compdata_folder = os.path.dirname( game_proton_bottle )
+    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+
+    if not os.path.exists( mania_planet_folder ):
+        log( "Could not find ManiaPlanet directory." )
+        log( "Creating new folder and symlinking Games to it." )
+        os.rename( game_proton_bottle , mania_planet_folder )
+        os.symlink( mania_planet_folder, game_proton_bottle)
+
+        for game_id in mania_planet_games:
+            game_path = os.path.join( compdata_folder, str(game_id) )
+            if game_path == game_proton_bottle:
+                continue
+            if os.path.exists( game_path ):
+                os.remove( game_id )
+
+            os.symlink( mania_planet_folder, game_path )
+        log( "All DONE" )

--- a/protonfixes/gamefixes/264850.py
+++ b/protonfixes/gamefixes/264850.py
@@ -1,33 +1,35 @@
-""" Game fix for TrackMania2 Canyon Demo
+""" Game fix for TrackMania² Canyon Demo
 """
 #pylint: disable=C0103
 
+import os
 from protonfixes import util
 from protonfixes.logger import log
-import os
 
-mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+mania_planet_games = [264850, 228760, 232910, 243360, 264660,
+                      600720, 600730, 233070, 229870, 233050]
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+        With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
-    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
-    compdata_folder = os.path.dirname( game_proton_bottle )
-    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+    game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
+    compdata_folder = os.path.dirname(game_proton_bottle)
+    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists( mania_planet_folder ):
-        log( "Could not find ManiaPlanet directory." )
-        log( "Creating new folder and symlinking Games to it." )
-        os.rename( game_proton_bottle , mania_planet_folder )
-        os.symlink( mania_planet_folder, game_proton_bottle)
+    if not os.path.exists(mania_planet_folder):
+        log("Could not find ManiaPlanet directory.")
+        log("Creating new folder and symlinking Games to it.")
+        os.rename(game_proton_bottle, mania_planet_folder)
+        os.symlink(mania_planet_folder, game_proton_bottle)
 
         for game_id in mania_planet_games:
-            game_path = os.path.join( compdata_folder, str(game_id) )
+            game_path = os.path.join(compdata_folder, str(game_id))
             if game_path == game_proton_bottle:
                 continue
-            if os.path.exists( game_path ):
-                os.remove( game_id )
+            if os.path.exists(game_path):
+                os.remove(game_id)
 
-            os.symlink( mania_planet_folder, game_path )
-        log( "All DONE" )
+            os.symlink(mania_planet_folder, game_path)
+        log("All DONE")

--- a/protonfixes/gamefixes/264850.py
+++ b/protonfixes/gamefixes/264850.py
@@ -1,0 +1,33 @@
+""" Game fix for TrackMania2 Canyon Demo
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+import os
+
+mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+
+def main():
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """
+
+    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
+    compdata_folder = os.path.dirname( game_proton_bottle )
+    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+
+    if not os.path.exists( mania_planet_folder ):
+        log( "Could not find ManiaPlanet directory." )
+        log( "Creating new folder and symlinking Games to it." )
+        os.rename( game_proton_bottle , mania_planet_folder )
+        os.symlink( mania_planet_folder, game_proton_bottle)
+
+        for game_id in mania_planet_games:
+            game_path = os.path.join( compdata_folder, str(game_id) )
+            if game_path == game_proton_bottle:
+                continue
+            if os.path.exists( game_path ):
+                os.remove( game_id )
+
+            os.symlink( mania_planet_folder, game_path )
+        log( "All DONE" )

--- a/protonfixes/gamefixes/600720.py
+++ b/protonfixes/gamefixes/600720.py
@@ -1,4 +1,4 @@
-""" Game fix for TrackMania² Stadium
+""" Game fix for Trackmania² Lagoon
 """
 #pylint: disable=C0103
 

--- a/protonfixes/gamefixes/600730.py
+++ b/protonfixes/gamefixes/600730.py
@@ -1,0 +1,33 @@
+""" Game fix for Trackmania2 Lagoon Demo
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+import os
+
+mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+
+def main():
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """
+
+    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
+    compdata_folder = os.path.dirname( game_proton_bottle )
+    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+
+    if not os.path.exists( mania_planet_folder ):
+        log( "Could not find ManiaPlanet directory." )
+        log( "Creating new folder and symlinking Games to it." )
+        os.rename( game_proton_bottle , mania_planet_folder )
+        os.symlink( mania_planet_folder, game_proton_bottle)
+
+        for game_id in mania_planet_games:
+            game_path = os.path.join( compdata_folder, str(game_id) )
+            if game_path == game_proton_bottle:
+                continue
+            if os.path.exists( game_path ):
+                os.remove( game_id )
+
+            os.symlink( mania_planet_folder, game_path )
+        log( "All DONE" )

--- a/protonfixes/gamefixes/600730.py
+++ b/protonfixes/gamefixes/600730.py
@@ -1,33 +1,35 @@
-""" Game fix for Trackmania2 Lagoon Demo
+""" Game fix for Trackmania² Lagoon Demo
 """
 #pylint: disable=C0103
 
+import os
 from protonfixes import util
 from protonfixes.logger import log
-import os
 
-mania_planet_games = [600720,264850,228760,243360,232910,264660,600730,233070]
+mania_planet_games = [264850, 228760, 232910, 243360, 264660,
+                      600720, 600730, 233070, 229870, 233050]
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle to it so that you have one ManiaPlanet instant with all games. No matter what game you launched. (Same as in windows now) 
+    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+        With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
-    game_proton_bottle =  os.path.dirname( os.path.dirname(util.protonprefix()) )
-    compdata_folder = os.path.dirname( game_proton_bottle )
-    mania_planet_folder = os.path.join( compdata_folder ,"ManiaPlanet")
+    game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
+    compdata_folder = os.path.dirname(game_proton_bottle)
+    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists( mania_planet_folder ):
-        log( "Could not find ManiaPlanet directory." )
-        log( "Creating new folder and symlinking Games to it." )
-        os.rename( game_proton_bottle , mania_planet_folder )
-        os.symlink( mania_planet_folder, game_proton_bottle)
+    if not os.path.exists(mania_planet_folder):
+        log("Could not find ManiaPlanet directory.")
+        log("Creating new folder and symlinking Games to it.")
+        os.rename(game_proton_bottle, mania_planet_folder)
+        os.symlink(mania_planet_folder, game_proton_bottle)
 
         for game_id in mania_planet_games:
-            game_path = os.path.join( compdata_folder, str(game_id) )
+            game_path = os.path.join(compdata_folder, str(game_id))
             if game_path == game_proton_bottle:
                 continue
-            if os.path.exists( game_path ):
-                os.remove( game_id )
+            if os.path.exists(game_path):
+                os.remove(game_id)
 
-            os.symlink( mania_planet_folder, game_path )
-        log( "All DONE" )
+            os.symlink(mania_planet_folder, game_path)
+        log("All DONE")


### PR DESCRIPTION
In the compdata folder the games are linked via symlinks to the ManiaPlanet folder. This makes it possible to launch other trackmania games while running a mania planet game.
The renaming and resymlinking seems to work fast enough that the game doesn't crash at least on the systems i tested on. 
If someone might test it to confirm it would be helpful. The TrackMania Demos are free so easy candidates to test.