### PR TITLE
Added gamefix for Stealth Inc 2: A Game of Clones

### DIFF
--- a/protonfixes/gamefixes/329380.py
+++ b/protonfixes/gamefixes/329380.py
@@ -1,0 +1,14 @@
+""" Game fix Stealth Inc 2: A Game of Clones
+"""
+# pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+
+
+def main():
+    """ dsound is needed for audio
+    """
+
+    log('Installing dsound')
+    util.protontricks('dsound')


### PR DESCRIPTION
We need `dsound` to have audio in this game.