### PR TITLE
A Hat in Time: Don't install xact, enable D9VK

### DIFF
--- a/protonfixes/gamefixes/253230.py
+++ b/protonfixes/gamefixes/253230.py
@@ -1,5 +1,4 @@
 """ Game fix for A Hat in Time
-Source: https://github.com/ValveSoftware/Proton/issues/173
 """
 
 #pylint: disable=C0103
@@ -7,8 +6,7 @@ Source: https://github.com/ValveSoftware/Proton/issues/173
 from protonfixes import util
 
 def main():
-    """ Installs xact
+    """ Enables D9VK
     """
 
-    util.protontricks('xact')
-    util.winedll_override('xaudio2_7', 'n')
+    util.enable_d9vk()


### PR DESCRIPTION
Installing xact with winetricks causes the game to not launch at all on Proton 4.11-5 (for me atleast).
The game runs wine without it and has no audio issues.
I have played through the entire game with D9VK without issues.
Prefix needs to be deleted for the game to launch (so that xact doesn't get installed. Proton now comes with FAudio which works much better than xact)
D9VK is not needed but it lowers the stuttering and increases performance.