### PR TITLE
Steam launch options

### DIFF
--- a/protonfixes/fix.py
+++ b/protonfixes/fix.py
@@ -63,6 +63,26 @@ def run_fix(gameid):
 
     game = game_name() + ' ('+ gameid + ')'
     localpath = os.path.expanduser('~/.config/protonfixes/localfixes')
+
+    # execute default.py
+    if os.path.isfile(os.path.join(localpath, 'default.py')):
+        open(os.path.join(localpath, '__init__.py'), 'a').close()
+        sys.path.append(os.path.expanduser('~/.config/protonfixes'))
+        try:
+            game_module = import_module('localfixes.default')
+            log.info('Using local defaults for ' + game)
+            game_module.main()
+        except ImportError:
+            log.info('No local defaults found for ' + game)
+    else:
+        try:
+            game_module = import_module('protonfixes.gamefixes.default')
+            log.info('Using global defaults for ' + game)
+            game_module.main()
+        except ImportError:
+            log.info('No global defaults found')
+
+    # execute <gameid>.py
     if os.path.isfile(os.path.join(localpath, gameid + '.py')):
         open(os.path.join(localpath, '__init__.py'), 'a').close()
         sys.path.append(os.path.expanduser('~/.config/protonfixes'))

--- a/protonfixes/gamefixes/default.py
+++ b/protonfixes/gamefixes/default.py
@@ -1,0 +1,23 @@
+from protonfixes import util
+import os
+import sys
+
+def main():
+    """ global defaults
+    """
+    
+    # Steam commandline
+    def use_steam_commands():
+        pf_alias_list = list(filter(lambda item: '-pf_' in item, sys.argv))
+
+        for pf_alias in pf_alias_list:
+            sys.argv.remove(pf_alias)
+            if pf_alias == '-pf_winecfg':
+                util.winecfg()
+            elif pf_alias == '-pf_regedit':
+                util.regedit()
+            elif pf_alias.split('=')[0] == '-pf_tricks':
+                param = str(pf_alias.replace('-pf_tricks=',''))
+                util.protontricks(param)
+        
+    use_steam_commands()

--- a/protonfixes/gamefixes/default.py
+++ b/protonfixes/gamefixes/default.py
@@ -1,13 +1,14 @@
-from protonfixes import util
-import os
 import sys
+from protonfixes import util
 
 def main():
     """ global defaults
     """
-    
+
     # Steam commandline
     def use_steam_commands():
+        """ Parse aliases from Steam launch options
+        """
         pf_alias_list = list(filter(lambda item: '-pf_' in item, sys.argv))
 
         for pf_alias in pf_alias_list:
@@ -17,7 +18,7 @@ def main():
             elif pf_alias == '-pf_regedit':
                 util.regedit()
             elif pf_alias.split('=')[0] == '-pf_tricks':
-                param = str(pf_alias.replace('-pf_tricks=',''))
+                param = str(pf_alias.replace('-pf_tricks=', ''))
                 util.protontricks(param)
-        
+
     use_steam_commands()

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -366,6 +366,20 @@ def get_game_install_path():
     # only for `waitforexitandrun` command
     return os.environ['PWD']
 
+def get_game_exe_name():
+    """ Game executable name
+    """
+
+    # only for `waitforexitandrun` command
+    game_path = get_game_install_path()
+    game_name = 'UNKNOWN'
+    for idx, arg in enumerate(sys.argv):
+        if game_path in arg:
+            game_name = os.path.basename(arg)
+            break
+    log.debug('Detected executable: ' + game_name)
+    return game_name
+
 def winedll_override(dll, dtype):
     """ Add WINE dll override
     """

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -387,6 +387,24 @@ def winedll_override(dll, dtype):
     log.info('Overriding ' + dll + '.dll = ' + dtype)
     protonmain.g_session.dlloverrides[dll] = dtype
 
+def winecfg():
+    """ Run winecfg.exe
+    """
+    game_path = os.path.join(get_game_install_path(), get_game_exe_name())
+    replace_command(game_path, 'winecfg.exe')
+
+def regedit():
+    """ Run regedit.exe
+    """
+    game_path = os.path.join(get_game_install_path(), get_game_exe_name())
+    replace_command(game_path, 'regedit.exe')
+
+def control():
+    """ Run control.exe
+    """
+    game_path = os.path.join(get_game_install_path(), get_game_exe_name())
+    replace_command(game_path, 'control.exe')
+
 def disable_nvapi():
     """ Disable WINE nv* dlls
     """


### PR DESCRIPTION
tl;dr: Allow to use `protonfixes` from Steam launch options.

In particular:
1. Adds `default.py` "gamefix" support, both "global" and "local". Can be used to set some environment variables for all games. For example, I use this for `util.set_environment('__GL_SHOW_GRAPHICS_OSD', '1')`.
  Only one of them used at a time, if exist, "local" have higher priority.

2. Adds `util.get_game_exe_name()`.

3. Adds `util.winecfg()`, `util.regedit()` and `util.control()`, which are aliases for corresponding Wine tools.

4. Adds `-pf_` prefixed aliases (**p**roton**f**ixes), to use as command line parameters.
  Very basic, but something like `-pf_tricks=dsound  -pf_tricks=vcrun2017 -pf_winecfg` in Steam launch options should work. Commands after `-pf_tricks=` are normal `winetricks` commands.

Well, all this changes are not very useful for "gamefixes", rather for "developing" them or for messing with "localfixes". But, I guess, users may want to have them combined this way.