### PR TITLE
Added `-pf_dxvk_set` alias for `set_dxvk_option()`

### DIFF
--- a/protonfixes/gamefixes/default.py
+++ b/protonfixes/gamefixes/default.py
@@ -23,5 +23,9 @@ def main():
             elif pf_alias.split('=')[0] == '-pf_tricks':
                 param = str(pf_alias.replace('-pf_tricks=', ''))
                 util.protontricks(param)
+            elif pf_alias.split('=')[0] == '-pf_dxvk_set':
+                param = str(pf_alias.replace('-pf_dxvk_set=', ''))
+                dxvk_opt = param.split('=')
+                util.set_dxvk_option(str(dxvk_opt[0]), str(dxvk_opt[1]))
 
     use_steam_commands()

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -521,7 +521,11 @@ def set_dxvk_option(opt, val, cfile='/tmp/protonfixes_dxvk.conf'):
     section = conf.default_section
     dxvk_conf = os.path.join(get_game_install_path(), 'dxvk.conf')
 
-    conf.read(cfile)
+    # HACK: add [DEFAULT] section to the file
+    try:
+        conf.read(cfile)
+    except configparser.MissingSectionHeaderError:
+        conf.read_file(read_dxvk_conf(open(cfile)))
 
     if not conf.has_option(section, 'session') or conf.getint(section, 'session') != os.getpid():
         log.info('Creating new DXVK config')
@@ -541,6 +545,12 @@ def set_dxvk_option(opt, val, cfile='/tmp/protonfixes_dxvk.conf'):
 
     with open(cfile, 'w') as configfile:
         conf.write(configfile)
+
+    # HACK: remove [DEFAULT] section from the file
+    with open(cfile, 'r') as fini:
+        dxvkopts = fini.read().splitlines(True)
+    with open(cfile, 'w') as fdxvk:
+        fdxvk.writelines(dxvkopts[1:])
 
 def install_from_zip(url, filename, path=os.getcwd()):
     """ Install a file from a downloaded zip


### PR DESCRIPTION
Example:
* `-pf_dxvk_set=dxvk.hud=full` - show Full DXVK HUD
* `-pf_dxvk_set=d3d9.presentInterval=0` - disable Vsync (D9VK)
* `-pf_dxvk_set=dxgi.syncInterval=0`    - disable Vsync (DXVK)

_Note: newer DXVK versions supports per-game configuration sections (e.g. `[GameName.exe]`), thus I added simple hack to add/remove `[DEFAULT]` section from the file. Should be reviewed at some point, but works for me so far._