### PR TITLE
Fix engine module for unknown game engines

### DIFF
--- a/protonfixes/engine.py
+++ b/protonfixes/engine.py
@@ -110,8 +110,7 @@ class Engine():
 
         if self.engine_name is None:
             log.warn(ctx + ': Engine not defined')
-
-        if warn is not False:
+        elif warn is not False:
             log.warn(self.engine_name + ': ' + ctx + ': ' + msg)
         else:
             log.info(self.engine_name + ': ' + ctx + ': ' + msg)


### PR DESCRIPTION
Everything else seems works as expected.

For `-pf_nointro -pf_windowed -pf_dxvk_set=dxvk.hud=full`
**unknown game engine**
```
ProtonFixes[28597] INFO: Running protonfixes
ProtonFixes[28597] INFO: Engine: unknown Game engine
ProtonFixes[28597] INFO: Using local defaults for "Saints Row IV" (206420)
ProtonFixes[28597] WARN: nointro: Engine not defined
ProtonFixes[28597] WARN: windowed: Engine not defined
ProtonFixes[28597] INFO: Creating new DXVK config
ProtonFixes[28597] ADD: env: DXVK_CONFIG_FILE=/tmp/protonfixes_dxvk.conf
ProtonFixes[28597] ADD: DXVK: dxvk.hud = full
```
**known game engine**
```
ProtonFixes[23115] INFO: Running protonfixes
ProtonFixes[23115] INFO: Engine: Unity
ProtonFixes[23115] INFO: Engine: https://pcgamingwiki.com/wiki/Engine:Unity
ProtonFixes[23115] INFO: Using local defaults for "Kingdom: Classic" (368230)
ProtonFixes[23115] WARN: Unity: nointro: not supported
ProtonFixes[23115] INFO: Unity: windowed: borderless window
ProtonFixes[23115] INFO: Creating new DXVK config
ProtonFixes[23115] ADD: env: DXVK_CONFIG_FILE=/tmp/protonfixes_dxvk.conf
ProtonFixes[23115] ADD: DXVK: dxvk.hud = full
```