### PR TITLE
Do not import more then needed

### DIFF
--- a/protonfixes/__init__.py
+++ b/protonfixes/__init__.py
@@ -3,8 +3,6 @@
 
 import os
 import sys
-import traceback
-from . import fix
 
 if 'DEBUG' in os.environ:
     from . import debug
@@ -12,9 +10,12 @@ if 'DEBUG' in os.environ:
 RUN_CONDITIONS = [
     'STEAM_COMPAT_DATA_PATH' in os.environ,
     'PROTONFIXES_DISABLE' not in os.environ,
+    'waitforexitandrun' in sys.argv[1],
 ]
 
 if all(RUN_CONDITIONS):
+    import traceback
+    from . import fix
     try:
         fix.main()
 


### PR DESCRIPTION
AFAIK `waitforexitandrun` the only "action" which we should care about.
So,  we shouldn't attempt to run anything on the `run` proton's "actions".

Fixes multiple `WARN: Optional dependency cefpython3 not found` in the log file.