### PR TITLE
Fix 'SyntaxWarning: "is" with a literal. Did you mean "=="?' warning in engine.py

### DIFF
--- a/protonfixes/engine.py
+++ b/protonfixes/engine.py
@@ -137,7 +137,7 @@ class Engine():
         """ Disable splash screen
         """
 
-        if self.engine_name is 'UE3':
+        if self.engine_name == 'UE3':
             self._add_argument('-nosplash')
             self._log('nosplash', 'splash screen disabled', True)
         else:
@@ -148,7 +148,7 @@ class Engine():
         """ Show some information about engine
         """
 
-        if self.engine_name is 'RAGE':
+        if self.engine_name == 'RAGE':
             self._add_argument('-help')
             self._log('info', 'command line arguments')
         else:
@@ -159,10 +159,10 @@ class Engine():
         """ Skip intro videos
         """
 
-        if self.engine_name is 'UE3':
+        if self.engine_name == 'UE3':
             self._add_argument('-nostartupmovies')
             self._log('nointro', 'intro videos disabled')
-        elif self.engine_name is 'Dunia 2':
+        elif self.engine_name == 'Dunia 2':
             self._add_argument('-skipintro')
             self._log('nointro', 'intro videos disabled')
         else:
@@ -173,7 +173,7 @@ class Engine():
         """ Force launcher
         """
 
-        if self.engine_name is 'Unity':
+        if self.engine_name == 'Unity':
             self._add_argument('-show-screen-selector')
             self._log('launcher', 'forced')
         else:
@@ -183,10 +183,10 @@ class Engine():
         """ Force windowed mode
         """
 
-        if self.engine_name is 'Unity':
+        if self.engine_name == 'Unity':
             self._add_argument('-popupwindow -screen-fullscreen 0')
             self._log('windowed', 'borderless window')
-        elif self.engine_name is 'RAGE':
+        elif self.engine_name == 'RAGE':
             self._add_argument('-windowed')
             self._log('windowed', 'window')
         else:
@@ -200,10 +200,10 @@ class Engine():
         if res is not None:
             res_wh = res.split('x')
 
-        if self.engine_name is 'Unity':
+        if self.engine_name == 'Unity':
             self._add_argument('-screen-width ' + res_wh[0] + ' -screen-height ' + res_wh[1])
             self._log('resolution', res)
-        elif self.engine_name is 'RAGE':
+        elif self.engine_name == 'RAGE':
             self._add_argument('-width ' + res_wh[0] + ' -height ' + res_wh[1])
             self._log('resolution', res)
         else:


### PR DESCRIPTION
Python 3.8 has introduced a warning when the `is` operator is used inappropriately (see [this](https://bugs.python.org/issue34850) for a thorough explanation)  
The gist of the problem is that the use of the `is` operator for string comparison accidentally works on CPython (the standard python interpreter) however such behavior is not guaranteed with other python implementations or future versions of CPython
This PR replaces the `is` operator with `==` where applicable.