### PR TITLE
Add protonfixes for Recettear and Chantelise

### DIFF
--- a/protonfixes/gamefixes/70400.py
+++ b/protonfixes/gamefixes/70400.py
@@ -1,0 +1,22 @@
+""" Game fix for Recettear: An Item Shop's Tale
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Install directsound libraries
+    """
+
+    util.protontricks('dmime')
+    util.protontricks('dmloader')
+    util.protontricks('dmsynth')
+    util.protontricks('dmusic')
+    util.protontricks('dsound')
+    util.protontricks('dswave')
+    util.winedll_override('streamci', 'n')
+    util.protontricks('sound=alsa')
+
+    """ Fix for audio stutter/desync
+    """
+    util.set_environment('PULSE_LATENCY_MSEC', '60')

--- a/protonfixes/gamefixes/70420.py
+++ b/protonfixes/gamefixes/70420.py
@@ -1,0 +1,22 @@
+""" Game fix for Chantelise - A Tale of Two Sisters
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Install directsound libraries
+    """
+
+    util.protontricks('dmime')
+    util.protontricks('dmloader')
+    util.protontricks('dmsynth')
+    util.protontricks('dmusic')
+    util.protontricks('dsound')
+    util.protontricks('dswave')
+    util.winedll_override('streamci', 'n')
+    util.protontricks('sound=alsa')
+
+    """ Fix for audio stutter/desync
+    """
+    util.set_environment('PULSE_LATENCY_MSEC', '60')


### PR DESCRIPTION
This PR add support for the following games:
70400 - Recettear: An Item Shop's Tale
70420 - Chantelise - A Tale of Two Sisters

Both fixes are identical since the underlying game engine is the same