### PR TITLE
Allow global gamefixes to be disabled

### DIFF
--- a/protonfixes/config.py
+++ b/protonfixes/config.py
@@ -10,6 +10,7 @@ DEFAULT_CONF = '''
 enable_checks = true
 enable_splash = true
 enable_font_links = true
+enable_global_fixes = true
 
 [path]
 cache_dir = ~/.cache/protonfixes

--- a/protonfixes/fix.py
+++ b/protonfixes/fix.py
@@ -74,7 +74,7 @@ def run_fix(gameid):
             game_module.main()
         except ImportError:
             log.info('No local defaults found for ' + game)
-    else:
+    elif config.enable_global_fixes:
         try:
             game_module = import_module('protonfixes.gamefixes.default')
             log.info('Using global defaults for ' + game)
@@ -92,7 +92,7 @@ def run_fix(gameid):
             game_module.main()
         except ImportError:
             log.info('No local protonfix found for ' + game)
-    else:
+    elif config.enable_global_fixes:
         try:
             game_module = import_module('protonfixes.gamefixes.' + gameid)
             log.info('Using protonfix for ' + game)


### PR DESCRIPTION
Sometimes user may want to disable predefined gamefixes.
For e.g. specific setups or testing purposes.