### PR TITLE
Add protonversion.py

### DIFF
--- a/protonfixes/debug.py
+++ b/protonfixes/debug.py
@@ -5,7 +5,8 @@ import os
 import sys
 import shutil
 # pylint: disable=E0611
-from .protonmain_compat import protonmain, CURRENT_PREFIX_VERSION
+from .protonmain_compat import protonmain
+from .protonversion import PROTON_VERSION
 from .logger import log
 
 os.environ['DEBUG'] = '1'
@@ -37,7 +38,7 @@ def show_debug_info():
     log.debug(line)
 
     log.debug('Proton Version:')
-    log.debug(CURRENT_PREFIX_VERSION)
+    log.debug(PROTON_VERSION)
     log.debug(line)
 
     log.debug('Proton Directory:')

--- a/protonfixes/protonmain_compat.py
+++ b/protonfixes/protonmain_compat.py
@@ -3,27 +3,12 @@
 #pylint: disable=R0903,R1705
 
 import os
-from .logger import log
-try:
-    from __main__ import CURRENT_PREFIX_VERSION
-except ImportError:
-    log.warn('Unable to hook into Proton main script environment')
+from .protonversion import (semver_cmp,
+                            version_dicttotuple,
+                            PROTON_VERSION)
 
-RELEASE = [int(CURRENT_PREFIX_VERSION.split('.')[0]),
-           int(CURRENT_PREFIX_VERSION.split('.')[1].split('-')[0]),
-           int(CURRENT_PREFIX_VERSION.split('.')[1].split('-')[1])]
+RELEASE = version_dicttotuple(PROTON_VERSION)
 OLD_PROTON = [4, 11, 1]
-
-
-def semver_cmp(ver_1, ver_2):
-    """ Compares 2 semver tuples, return True if ver_1 > ver_2, False otherwise
-    """
-    for i in range(0, 3):
-        if ver_1[i] > ver_2[i]:
-            return True
-        elif ver_1[i] < ver_2[i]:
-            return False
-    return False
 
 
 PROTON_MAP = {'base_dir': 'basedir',

--- a/protonfixes/protonmain_compat.py
+++ b/protonfixes/protonmain_compat.py
@@ -3,12 +3,9 @@
 #pylint: disable=R0903,R1705
 
 import os
-from .protonversion import (semver_cmp,
-                            version_dicttotuple,
-                            PROTON_VERSION)
+from .protonversion import semver_cmp, PROTON_VERSION
 
-RELEASE = version_dicttotuple(PROTON_VERSION)
-OLD_PROTON = [4, 11, 1]
+OLD_PROTON = "4.11-1"
 
 
 PROTON_MAP = {'base_dir': 'basedir',
@@ -60,7 +57,7 @@ class ProtonCompat():
         self.g_compatdata = self.g_proton
 
 
-if not semver_cmp(OLD_PROTON, RELEASE):
+if not semver_cmp(OLD_PROTON, PROTON_VERSION):
     import __main__ as protonmain #pylint: disable=W0611
 else:
     import __main__ as old_protonmain

--- a/protonfixes/protonversion.py
+++ b/protonfixes/protonversion.py
@@ -1,0 +1,69 @@
+""" Module for dealing with proton version
+"""
+
+import os
+import re
+import sys
+from .logger import log
+try:
+    from __main__ import CURRENT_PREFIX_VERSION
+except ImportError:
+    log.warn('Unable to hook into Proton main script environment')
+    _PATH_VERSION = re.search(r'Proton (\d*\.\d*)', sys.argv[0])
+    if _PATH_VERSION:
+        CURRENT_PREFIX_VERSION = _PATH_VERSION.group(1)
+
+VERSION_RE = re.compile(r'(|proton-)(?P<major>\d+)\.(?P<minor>\d+)'+
+                        r'(|-(?P<flavor>.*?))-(?P<release>\d+)')
+
+
+def semver_cmp(ver_1, ver_2):
+    """ Compares 2 semver tuples, return True if ver_1 > ver_2, False otherwise
+    """
+    for i in range(0, min(len(ver_1), len(ver_2))):
+        if ver_1[i] > ver_2[i]: #pylint: disable=no-else-return
+            return True
+        elif ver_1[i] < ver_2[i]:
+            return False
+    return False
+
+
+def parse_protonversion(version_string):
+    """ Given a proton version string, return a dict with
+        'major', 'minor', 'release' and 'flavor' (eg. GE) if present
+    """
+    version_re = VERSION_RE.match(version_string)
+    if version_re:
+        return version_re.groupdict()
+    return {}
+
+
+def version_dicttotuple(dict_version):
+    """ Converts a version dictionary into a tuple
+    """
+    return (dict_version['major'],
+            dict_version['minor'],
+            dict_version['release'])
+
+
+def init():
+    """ Initialization function that will create PROTON_VERSION and
+        PROTON_TIMESTAMP from the version file
+    """
+    proton_version = parse_protonversion(CURRENT_PREFIX_VERSION)
+    proton_timestamp = 0
+    proton_path = os.path.dirname(sys.argv[0])
+    proton_version_file = os.path.join(proton_path, 'version')
+    try:
+        with open(proton_version_file) as version_f:
+            version_str = version_f.readline().strip()
+            version_components = version_str.split(' ', 2)
+            proton_timestamp = int(version_components[0])
+            if len(version_components) == 2:
+                proton_version = parse_protonversion(version_components[1])
+    except OSError:
+        log.warn('Proton version file not found in: ' + proton_path)
+    return (proton_version, proton_timestamp)
+
+
+PROTON_VERSION, PROTON_TIMESTAMP = init()

--- a/protonfixes/protonversion.py
+++ b/protonfixes/protonversion.py
@@ -46,6 +46,25 @@ def version_dicttotuple(dict_version):
             dict_version['release'])
 
 
+def DeprecatedSince(version): #pylint: disable=invalid-name
+    """ Decorator to indicate that a fix should only be applied to
+        versions older than version
+    """
+    def decorator(function):
+        def wrapper(*args, **kwargs):
+            if isinstance(version, int):
+                if version > PROTON_TIMESTAMP:
+                    return function(*args, **kwargs)
+            elif isinstance(version, str):
+                target_version_tuple = version_dicttotuple(parse_protonversion(version))
+                proton_version_tuple = version_dicttotuple(PROTON_VERSION)
+                if semver_cmp(target_version_tuple, proton_version_tuple):
+                    return function(*args, **kwargs)
+            return None
+        return wrapper
+    return decorator
+
+
 def init():
     """ Initialization function that will create PROTON_VERSION and
         PROTON_TIMESTAMP from the version file

--- a/protonfixes/protonversion.py
+++ b/protonfixes/protonversion.py
@@ -20,6 +20,14 @@ VERSION_RE = re.compile(r'(|proton-)(?P<major>\d+)\.(?P<minor>\d+)'+
 def semver_cmp(ver_1, ver_2):
     """ Compares 2 semver tuples, return True if ver_1 > ver_2, False otherwise
     """
+    if isinstance(ver_1, str):
+        ver_1 = parse_protonversion(ver_1)
+    if isinstance(ver_1, dict):
+        ver_1 = version_dicttotuple(ver_1)
+    if isinstance(ver_2, str):
+        ver_2 = parse_protonversion(ver_2)
+    if isinstance(ver_2, dict):
+        ver_2 = version_dicttotuple(ver_2)
     for i in range(0, min(len(ver_1), len(ver_2))):
         if ver_1[i] > ver_2[i]: #pylint: disable=no-else-return
             return True
@@ -56,9 +64,7 @@ def DeprecatedSince(version): #pylint: disable=invalid-name
                 if version > PROTON_TIMESTAMP:
                     return function(*args, **kwargs)
             elif isinstance(version, str):
-                target_version_tuple = version_dicttotuple(parse_protonversion(version))
-                proton_version_tuple = version_dicttotuple(PROTON_VERSION)
-                if semver_cmp(target_version_tuple, proton_version_tuple):
+                if semver_cmp(version, PROTON_VERSION):
                     return function(*args, **kwargs)
             return None
         return wrapper

--- a/protonfixes/protonversion.py
+++ b/protonfixes/protonversion.py
@@ -41,9 +41,9 @@ def parse_protonversion(version_string):
 def version_dicttotuple(dict_version):
     """ Converts a version dictionary into a tuple
     """
-    return (dict_version['major'],
-            dict_version['minor'],
-            dict_version['release'])
+    return (int(dict_version['major']),
+            int(dict_version['minor']),
+            int(dict_version['release']))
 
 
 def DeprecatedSince(version): #pylint: disable=invalid-name

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -14,6 +14,7 @@ import functools
 from .logger import log
 from . import config
 from .protonmain_compat import protonmain
+from .protonversion import PROTON_VERSION, PROTON_TIMESTAMP
 
 # pylint: disable=unreachable
 
@@ -47,30 +48,15 @@ def protonprefix():
 
 
 def protonnameversion():
-    """ Returns the version of proton from sys.argv[0]
+    """ Returns the version of proton
     """
-
-    version = re.search('Proton ([0-9]*\\.[0-9]*)', sys.argv[0])
-    if version:
-        return version.group(1)
-    log.warn('Proton version not parsed from command line')
-    return None
+    return '{major}.{minor}'.format(**PROTON_VERSION)
 
 
 def protontimeversion():
     """ Returns the version timestamp of proton from the `version` file
     """
-
-    fullpath = os.path.join(protondir(), 'version')
-    try:
-        with open(fullpath, 'r') as version:
-            for timestamp in version.readlines():
-                return int(timestamp.strip())
-    except OSError:
-        log.warn('Proton version file not found in: ' + fullpath)
-        return 0
-    log.warn('Proton version not parsed from file: ' + fullpath)
-    return 0
+    return PROTON_TIMESTAMP
 
 
 def protonversion(timestamp=False):


### PR DESCRIPTION
Aggregate all the version-related functions of `protonmain_compat.py` and `utils.py` into `protonversion.py`
Improve version retrieval and checking by using the `version` file for both timestamp and release version (as it is more accurate than `CURRENT_PREFIX_VERSION`)
Implement `DeprecatedSince` decorator, when applied to a function and given a suitable version either in timestamp form (int) or version form (string) it will execute the function only if the version is lower (excluding) than the one specified, should be useful in cases outlined [here](https://github.com/simons-public/protonfixes/pull/111#issuecomment-591997293)