### PR TITLE
Splash overhaul

### DIFF
--- a/protonfixes/config.py
+++ b/protonfixes/config.py
@@ -10,6 +10,8 @@ DEFAULT_CONF = '''
 enable_checks = true
 enable_splash = true
 enable_font_links = true
+splash_preference = zenity,cef
+zenity_bigpicture = false
 
 [path]
 cache_dir = ~/.cache/protonfixes
@@ -25,16 +27,16 @@ except Exception:
     log.debug('Unable to read config file ' + CONF_FILE)
 
 def opt_bool(opt):
-    """ Convert bool ini strings to actual boolean values
+    """ Convert bool ini strings to actual boolean values, if needed
     """
 
-    return opt.lower() in ['yes', 'y', 'true', '1']
+    if opt.lower() in ['yes', 'y', 'true', '1', 'no', 'n', 'false', '0']:
+        return opt.lower() in ['yes', 'y', 'true', '1']
+    return opt
 
 # pylint: disable=E1101
-locals().update(
-    {x:opt_bool(y) for x, y
-     in CONF['main'].items()
-     if 'enable' in x})
+locals().update({x:opt_bool(y) for x, y
+                 in CONF['main'].items()})
 
 locals().update({x:os.path.expanduser(y) for x, y in CONF['path'].items()})
 

--- a/protonfixes/download.py
+++ b/protonfixes/download.py
@@ -5,6 +5,7 @@ import os
 import hashlib
 import urllib.request
 import http.cookiejar
+from .progress import TrackProgress
 
 
 GDRIVE_URL = 'https://drive.google.com/uc?id={}&export=download'
@@ -19,6 +20,7 @@ def get_filename(headers):
     return raw_filename.replace('filename=', '').replace('"', '')
 
 
+@TrackProgress("Downloading file from gdrive")
 def gdrive_download(gdrive_id, path):
     """ Download a file from gdrive given the fileid and a path to save
     """

--- a/protonfixes/download.py
+++ b/protonfixes/download.py
@@ -3,9 +3,12 @@
 
 import os
 import hashlib
+import zipfile
 import urllib.request
 import http.cookiejar
 from .progress import TrackProgress
+from .logger import log
+from . import config
 
 
 GDRIVE_URL = 'https://drive.google.com/uc?id={}&export=download'
@@ -41,12 +44,50 @@ def gdrive_download(gdrive_id, path):
         save_file.write(resp2.read())
 
 
+@TrackProgress("Downloading zip from: {}")
+def install_from_zip(url, filename, path=os.getcwd(), filesha=None):
+    """ Install a file from a downloaded zip
+    """
+
+    if (os.path.isfile(os.path.join(path, filename))
+            and filesha is not None
+            and sha256sum(filename) == filesha):
+        log.info('File ' + filename + ' found in ' + path)
+        return
+
+    cache_dir = config.cache_dir
+    zip_file_name = os.path.basename(url)
+    zip_file_path = os.path.join(cache_dir, zip_file_name)
+
+    if zip_file_name not in os.listdir(cache_dir):
+        log.info('Downloading ' + filename + ' to ' + zip_file_path)
+        urllib.request.urlretrieve(url, zip_file_path)
+
+    with zipfile.ZipFile(zip_file_path, 'r') as zip_obj:
+        log.info('Extracting ' + filename + ' to ' + path)
+        zip_obj.extract(filename, path=path)
+
+
 def sha1sum(filename):
     """ Computes the sha1sum of the specified file
     """
     if not os.path.isfile(filename):
         return ''
     hasher = hashlib.sha1()
+    with open(filename, 'rb') as hash_file:
+        buf = hash_file.read(HASH_BLOCK_SIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            buf = hash_file.read(HASH_BLOCK_SIZE)
+    return hasher.hexdigest()
+
+
+def sha256sum(filename):
+    """ Computes the sha1sum of the specified file
+    """
+    if not os.path.isfile(filename):
+        return ''
+    hasher = hashlib.sha256()
     with open(filename, 'rb') as hash_file:
         buf = hash_file.read(HASH_BLOCK_SIZE)
         while len(buf) > 0:

--- a/protonfixes/fix.py
+++ b/protonfixes/fix.py
@@ -13,6 +13,7 @@ from .util import protonprefix
 from .checks import run_checks
 from .logger import log
 from . import config
+from . import progress
 
 # These modules need to be imported for TrackProgress
 from . import util as _util #pylint: disable=unused-import
@@ -88,18 +89,23 @@ def run_fix(gameid):
             log.info('No global defaults found')
 
     # execute <gameid>.py
-    if os.path.isfile(os.path.join(localpath, gameid + '.py')):
+    localfix_py = os.path.join(localpath, gameid + '.py')
+    if os.path.isfile(localfix_py):
         open(os.path.join(localpath, '__init__.py'), 'a').close()
         sys.path.append(os.path.expanduser('~/.config/protonfixes'))
         try:
             game_module = import_module('localfixes.' + gameid)
+            progress.parse_fix(localfix_py)
             log.info('Using local protonfix for ' + game)
             game_module.main()
         except ImportError:
             log.info('No local protonfix found for ' + game)
     elif config.enable_global_fixes:
+        globalfix_py = os.path.join(os.path.dirname(__file__),
+                                    'gamefixes', gameid + '.py')
         try:
             game_module = import_module('protonfixes.gamefixes.' + gameid)
+            progress.parse_fix(globalfix_py)
             log.info('Using protonfix for ' + game)
             game_module.main()
         except ImportError:

--- a/protonfixes/fix.py
+++ b/protonfixes/fix.py
@@ -14,6 +14,11 @@ from .checks import run_checks
 from .logger import log
 from . import config
 
+# These modules need to be imported for TrackProgress
+from . import util as _util #pylint: disable=unused-import
+from . import download as _download #pylint: disable=unused-import
+
+
 def game_id():
     """ Trys to return the game id from environment variables
     """

--- a/protonfixes/fix.py
+++ b/protonfixes/fix.py
@@ -57,6 +57,24 @@ def game_name():
     return 'UNKNOWN'
 
 
+def install_corefonts():
+    """ Downloads and installs corefonts in the prefix
+    """
+    # get corefonts
+    if not check_corefonts():
+        log.info('Getting ms corefonts')
+        get_corefonts()
+
+    # install corefonts
+    fontsdir = os.path.join(protonprefix(), 'drive_c/windows/Fonts')
+    try:
+        os.makedirs(fontsdir)
+    except FileExistsError:
+        log.debug('Fonts directory exists')
+    if len(os.listdir(fontsdir)) < 30:
+        link_fonts(fontsdir)
+
+
 def run_fix(gameid):
     """ Loads a gamefix module by it's gameid
     """
@@ -112,19 +130,7 @@ def run_fix(gameid):
             log.info('No protonfix found for ' + game)
 
     if config.enable_font_links:
-        # get corefonts
-        if not check_corefonts():
-            log.info('Getting ms corefonts')
-            get_corefonts()
-
-        # install corefonts
-        fontsdir = os.path.join(protonprefix(), 'drive_c/windows/Fonts')
-        try:
-            os.makedirs(fontsdir)
-        except FileExistsError:
-            log.debug('Fonts directory exists')
-        if len(os.listdir(fontsdir)) < 30:
-            link_fonts(fontsdir)
+        install_corefonts()
 
 
 def main():

--- a/protonfixes/gamefixes/250180.py
+++ b/protonfixes/gamefixes/250180.py
@@ -1,14 +1,9 @@
 """ Game fix for Metal Slug 3
 """
 # pylint: disable=C0103
-import hashlib
-import io
-import os.path
-import urllib.request
-import zipfile
-
 from protonfixes.logger import log
-from protonfixes import util
+from protonfixes import util, download
+
 
 REPLACEMENT_DLLS = {
     'd3dcompiler_46.dll': {
@@ -25,6 +20,7 @@ REPLACEMENT_DLLS = {
     }
 }
 
+
 def main():
     """
     Replaces DLL files due to the versions bundled resulting
@@ -35,38 +31,8 @@ def main():
     metal_slug_path = util.get_game_install_path()
 
     # download new DLL files and replace existing ones
-    for dll in REPLACEMENT_DLLS:
-        # check if current dlls are already the replacements
-        cur_dll_path = os.path.join(metal_slug_path, dll)
-        cur_sha = hashlib.sha256()
-
-        try:
-            with open(cur_dll_path, 'rb') as cur_dll_data:
-                cur_sha.update(cur_dll_data.read())
-
-            if cur_sha.hexdigest() == REPLACEMENT_DLLS[dll]['sha256']:
-                log(f"{dll} is already the replacement dll. Skipping replacing it...")
-                continue
-        except FileNotFoundError:
-            log(f"{dll} not found, will use the one from the zip.")
-
-        req = urllib.request.urlopen(REPLACEMENT_DLLS[dll]['url'])
-        # check http return code and if not 200 log and skip file
-        if req.getcode() != 200:
-            log(f"Received HTTP {req.status} when downloading replacement DLL {dll} skipping...")
-            continue
-
-        dll_zip = zipfile.ZipFile(io.BytesIO(req.read()))
-        dll_data = dll_zip.open(dll.lower())
-
-        sha = hashlib.sha256()
-        sha.update(dll_data.read())
-
-        if sha.hexdigest() != REPLACEMENT_DLLS[dll]['sha256']:
-            log(f"DLL SHA256 does not match for {dll} skipping...")
-            continue
-
-        dll_data = dll_zip.open(dll.lower())
-        with open(cur_dll_path, 'wb') as out_dll:
-            log(f"Writing replacement DLL data to {cur_dll_path}")
-            out_dll.write(dll_data.read())
+    for dll, props in REPLACEMENT_DLLS.items():
+        download.install_from_zip(props['url'],
+                                  dll,
+                                  metal_slug_path,
+                                  props['sha256'])

--- a/protonfixes/gamefixes/366250.py
+++ b/protonfixes/gamefixes/366250.py
@@ -1,14 +1,9 @@
 """ Game fix for Metal Slug
 """
 # pylint: disable=C0103
-import hashlib
-import io
-import os.path
-import urllib.request
-import zipfile
-
-from protonfixes import util
+from protonfixes import util, download
 from protonfixes.logger import log
+
 
 REPLACEMENT_DLLS = {
     'd3dcompiler_46.dll': {
@@ -25,6 +20,7 @@ REPLACEMENT_DLLS = {
     }
 }
 
+
 def main():
     """
     Replaces DLL files due to the versions bundled resulting
@@ -35,38 +31,8 @@ def main():
     metal_slug_path = util.get_game_install_path()
 
     # download new DLL files and replace existing ones
-    for dll in REPLACEMENT_DLLS:
-        # check if current dlls are already the replacements
-        cur_dll_path = os.path.join(metal_slug_path, dll)
-        cur_sha = hashlib.sha256()
-
-        try:
-            with open(cur_dll_path, 'rb') as cur_dll_data:
-                cur_sha.update(cur_dll_data.read())
-
-            if cur_sha.hexdigest() == REPLACEMENT_DLLS[dll]['sha256']:
-                log(f"{dll} is already the replacement dll. Skipping replacing it...")
-                continue
-        except FileNotFoundError:
-            log(f"{dll} not found, will use the one from the zip.")
-
-        req = urllib.request.urlopen(REPLACEMENT_DLLS[dll]['url'])
-        # check http return code and if not 200 log and skip file
-        if req.getcode() != 200:
-            log(f"Received HTTP {req.status} when downloading replacement DLL {dll} skipping...")
-            continue
-
-        dll_zip = zipfile.ZipFile(io.BytesIO(req.read()))
-        dll_data = dll_zip.open(dll.lower())
-
-        sha = hashlib.sha256()
-        sha.update(dll_data.read())
-
-        if sha.hexdigest() != REPLACEMENT_DLLS[dll]['sha256']:
-            log(f"DLL SHA256 does not match for {dll} skipping...")
-            continue
-
-        dll_data = dll_zip.open(dll.lower())
-        with open(cur_dll_path, 'wb') as out_dll:
-            log(f"Writing replacement DLL data to {cur_dll_path}")
-            out_dll.write(dll_data.read())
+    for dll, props in REPLACEMENT_DLLS.items():
+        download.install_from_zip(props['url'],
+                                  dll,
+                                  metal_slug_path,
+                                  props['sha256'])

--- a/protonfixes/gamefixes/366260.py
+++ b/protonfixes/gamefixes/366260.py
@@ -1,14 +1,9 @@
 """ Game fix for Metal Slug 2
 """
 # pylint: disable=C0103
-import hashlib
-import io
-import os.path
-import urllib.request
-import zipfile
-
-from protonfixes import util
+from protonfixes import util, download
 from protonfixes.logger import log
+
 
 REPLACEMENT_DLLS = {
     'd3dcompiler_46.dll': {
@@ -25,6 +20,7 @@ REPLACEMENT_DLLS = {
     }
 }
 
+
 def main():
     """
     Replaces DLL files due to the versions bundled resulting
@@ -35,38 +31,8 @@ def main():
     metal_slug_path = util.get_game_install_path()
 
     # download new DLL files and replace existing ones
-    for dll in REPLACEMENT_DLLS:
-        # check if current dlls are already the replacements
-        cur_dll_path = os.path.join(metal_slug_path, dll)
-        cur_sha = hashlib.sha256()
-
-        try:
-            with open(cur_dll_path, 'rb') as cur_dll_data:
-                cur_sha.update(cur_dll_data.read())
-
-            if cur_sha.hexdigest() == REPLACEMENT_DLLS[dll]['sha256']:
-                log(f"{dll} is already the replacement dll. Skipping replacing it...")
-                continue
-        except FileNotFoundError:
-            log(f"{dll} not found, will use the one from the zip.")
-
-        req = urllib.request.urlopen(REPLACEMENT_DLLS[dll]['url'])
-        # check http return code and if not 200 log and skip file
-        if req.getcode() != 200:
-            log(f"Received HTTP {req.status} when downloading replacement DLL {dll} skipping...")
-            continue
-
-        dll_zip = zipfile.ZipFile(io.BytesIO(req.read()))
-        dll_data = dll_zip.open(dll.lower())
-
-        sha = hashlib.sha256()
-        sha.update(dll_data.read())
-
-        if sha.hexdigest() != REPLACEMENT_DLLS[dll]['sha256']:
-            log(f"DLL SHA256 does not match for {dll} skipping...")
-            continue
-
-        dll_data = dll_zip.open(dll.lower())
-        with open(cur_dll_path, 'wb') as out_dll:
-            log(f"Writing replacement DLL data to {cur_dll_path}")
-            out_dll.write(dll_data.read())
+    for dll, props in REPLACEMENT_DLLS.items():
+        download.install_from_zip(props['url'],
+                                  dll,
+                                  metal_slug_path,
+                                  props['sha256'])

--- a/protonfixes/gamefixes/379720.py
+++ b/protonfixes/gamefixes/379720.py
@@ -2,7 +2,7 @@
 """
 #pylint: disable=C0103
 
-from protonfixes import util
+from protonfixes import util, download
 
 def main():
     """ Install vcrun2015
@@ -14,4 +14,7 @@ def main():
     # disable chroma implementation that is broken in wine
     # https://github.com/simons-public/protonfixes/issues/26
     chroma_url = 'https://github.com/Riesi/CChromaEditor/files/2277158/CChromaEditorLibrary.zip'
-    util.install_from_zip(chroma_url, 'CChromaEditorLibrary.dll')
+    download.install_from_zip(chroma_url,
+                              'CChromaEditorLibrary.dll',
+                              util.get_game_install_path(),
+                              '0b947580ed2a13dd8c8f0c987d5c7993281e64ab967368ba8d72c8b82e2d906a')

--- a/protonfixes/progress.py
+++ b/protonfixes/progress.py
@@ -1,0 +1,29 @@
+""" Module to track the progress of fixes
+"""
+
+from .logger import log
+
+
+TOTAL_STEPS = 0
+
+
+class TrackProgressFactory: #pylint: disable=invalid-name
+    #pylint: disable=too-few-public-methods
+    """ Class that counts the number of functions registered with
+        its decorator, and increments splash screen step every time
+        a function is called
+    """
+    registry = []
+
+    def __call__(self, fmt_string):
+        def decorator(function):
+            registry_entry = '{}.{}'.format(function.__module__,
+                                            function.__name__)
+            self.registry.append(registry_entry.replace('protonfixes.', ''))
+            def wrapper(*args, **kwargs):
+                log.info(fmt_string.format(*args, **kwargs))
+                return function(*args, **kwargs)
+            return wrapper
+        return decorator
+
+TrackProgress = TrackProgressFactory() #pylint: disable=invalid-name

--- a/protonfixes/progress.py
+++ b/protonfixes/progress.py
@@ -3,6 +3,7 @@
 
 import ast
 from .logger import log
+from . import splash
 
 
 CURRENT_STEP = 0
@@ -25,8 +26,10 @@ class TrackProgressFactory: #pylint: disable=invalid-name
                                             function.__name__)
             self.registry.append(registry_entry)
             def wrapper(*args, **kwargs):
-                log.info(fmt_string.format(*args, **kwargs))
-                return function(*args, **kwargs)
+                set_progress_text(fmt_string.format(*args, **kwargs))
+                res = function(*args, **kwargs)
+                increase_progress()
+                return res
             return wrapper
         return decorator
 
@@ -90,5 +93,20 @@ def parse_fix(path):
         visitor.visit(fix_ast)
     relevant_calls = [x for x in visitor.functioncalls
                       if x in TrackProgress.registry]
-    log.info(relevant_calls)
     TOTAL_STEPS = len(relevant_calls)
+
+
+def increase_progress():
+    """ Increases CURRENT_STEP and updates the progress bar
+    """
+    global CURRENT_STEP #pylint: disable=global-statement
+    CURRENT_STEP += 1
+    splash.set_splash_progress(int(CURRENT_STEP/(TOTAL_STEPS)*100))
+    log.debug("Step {}/{}".format(CURRENT_STEP, TOTAL_STEPS))
+
+
+
+def set_progress_text(text):
+    """ Sets the progress description text
+    """
+    splash.set_splash_text(text)

--- a/protonfixes/progress.py
+++ b/protonfixes/progress.py
@@ -109,4 +109,7 @@ def increase_progress():
 def set_progress_text(text):
     """ Sets the progress description text
     """
+    if len(text) > 50:
+        text = text[:50]
+        text += '...'
     splash.set_splash_text(text)

--- a/protonfixes/splash.py
+++ b/protonfixes/splash.py
@@ -4,7 +4,8 @@ import os
 import sys
 import time
 import subprocess
-from multiprocessing import Process
+import threading
+from multiprocessing import Process, Queue
 from contextlib import contextmanager
 from .logger import log
 from . import config
@@ -16,8 +17,24 @@ except ImportError:
     HAS_CEF = False
     log.warn('Optional dependency cefpython3 not found')
 
+
+STATUS = {}
+STATUS['cef_queue'] = Queue()
+
+
+def control_browser(cef_handle, queue):
+    """ Loop thread to send javascript calls to cef
+    """
+    while not cef_handle.HasDocument():
+        time.sleep(2)
+    cef_handle.ExecuteFunction('window.setWidth', 0)
+    while True:
+        operation = queue.get()
+        cef_handle.ExecuteFunction(operation[0], operation[1])
+
+
 #pylint: disable=W0621
-def browser(cef, url):
+def browser(cef, url, cef_queue):
     """ Starts a cef browser in the middle of the screen with url
     """
 
@@ -43,10 +60,13 @@ def browser(cef, url):
 
     win_info = cef.WindowInfo()
     win_info.SetAsChild(0, coordinates(600, 360))
+    brow = cef.CreateBrowserSync(url=url, window_info=win_info, window_title='splash')
 
-    cef.CreateBrowser(url=url, window_info=win_info, window_title='splash')
+    control_t = threading.Thread(target=control_browser, args=(brow, cef_queue))
+    control_t.start()
     cef.MessageLoop()
     cef.Shutdown()
+
 
 def coordinates(width, height):
     """ Returns coordinates [x1, y1, x2, y2] for a centered box of width, height
@@ -89,7 +109,7 @@ def zenity_splash():
         'sleep 2;',
         zenity_bin,
         '--progress',
-        '--pulsate',
+        '--percentage=0',
         '--no-cancel',
         '--auto-close',
         '--text',
@@ -100,14 +120,17 @@ def zenity_splash():
     # but zenity forks and won't quit when the subprocess is killed,
     # hence, using shell=True and 'sleep 2;'
     zenity = subprocess.Popen(zenity_cmd,
+                              encoding='utf-8',
                               stdin=subprocess.PIPE,
-                              stdout=subprocess.PIPE,
+                              stdout=None,
+                              stderr=None,
                               shell=True,
                              )
-
+    STATUS['zenity_handle'] = zenity
     yield
     log.debug('Terminating zenity splash screen')
-    zenity.kill()
+    zenity.stdin.write('100\n')
+    zenity.stdin.flush()
 
 
 @contextmanager
@@ -119,7 +142,7 @@ def cef_splash(cef, page='index.html'):
     log.debug('Starting CEF splash screen')
     data_dir = os.path.join(os.path.dirname(__file__), 'static')
     url = 'file://' + os.path.join(data_dir, page)
-    cef_proc = Process(target=browser, args=(cef, url))
+    cef_proc = Process(target=browser, args=(cef, url, STATUS['cef_queue']))
     cef_proc.start()
     try:
         yield
@@ -143,6 +166,7 @@ def splash():
         if splash.strip() == 'cef' and HAS_CEF:
             log.debug('Using cefpython splash screen')
             with cef_splash(cef):
+                STATUS['handler'] = 'cef'
                 yield
                 return
 
@@ -150,9 +174,37 @@ def splash():
                 and (not is_bigpicture or config.zenity_bigpicture)):
             log.debug('Using zenity splash screen')
             with zenity_splash():
+                STATUS['handler'] = 'zenity'
                 yield
                 return
 
     log.warn('No splash dependencies found, running without splash screen')
     yield
     return
+
+def set_splash_text(text):
+    """ Set splash screen text
+    """
+    if STATUS['handler'] == 'zenity':
+        zenity = STATUS['zenity_handle']
+        zenity.stdin.write('#' + text + '\n')
+        zenity.stdin.flush()
+    elif STATUS['handler'] == 'cef':
+        cef_q = STATUS['cef_queue']
+        cef_q.put(('setText', text))
+    else:
+        log.info(text)
+
+
+def set_splash_progress(progress):
+    """ Set splash screen progress in a 0-100 scale
+    """
+    if STATUS['handler'] == 'zenity':
+        zenity = STATUS['zenity_handle']
+        zenity.stdin.write(str(progress) + '\n')
+        zenity.stdin.flush()
+    elif STATUS['handler'] == 'cef':
+        cef_q = STATUS['cef_queue']
+        cef_q.put(('setWidth', progress))
+    else:
+        log.info("Progress {}%".format(progress))

--- a/protonfixes/static/index.html
+++ b/protonfixes/static/index.html
@@ -13,8 +13,7 @@
       font-family: "Arial", "Helvetica", sans-serif;
     }
 
-    h1,
-    h3 {
+    h1, h3 {
       padding: 20px;
     }
 
@@ -39,53 +38,24 @@
       background: radial-gradient(circle at top right, #153445 0%, #081322 78%);
     }
 
-    .loader,
-    .loader:before,
-    .loader:after {
-      background: #79bcec;
-      animation: load1 1s infinite ease-in-out;
-      width: 3em;
-      height: 4em;
-    }
-
-    .loader {
-      color: #79bcec;
-      text-indent: -9999em;
-      margin: 50px auto;
+    #progress {
       position: relative;
-      font-size: 12px;
-      transform: translateZ(0);
-      animation-delay: -0.16s;
+      margin: 0 auto;
+      width: 80%;
+      border: 8px solid #79bcec;
+      height: 50px;
+      border-radius: 20px;
     }
 
-    .loader:before,
-    .loader:after {
-      position: absolute;
-      top: 0;
-      content: '';
+    #progress-bar {
+      position: relative;
+      top: 8%;
+      left: 1%;
+      height: 84%;
+      background-color: #79bcec;
+      border-radius: 5px;
     }
-
-    .loader:before {
-      left: -4em;
-      animation-delay: -0.32s;
-    }
-
-    .loader:after {
-      left: 4em;
-    }
-
-    @keyframes load1 {
-      0%,
-      80%,
-      100% {
-        box-shadow: 0 0;
-        height: 4em;
-      }
-      40% {
-        box-shadow: 0 -2em;
-        height: 5em;
-      }
-    }
+    </style>
   </style>
 </script>
 </head>
@@ -95,7 +65,23 @@
     <h1>ProtonFixes</h1>
     <hr>
     <h3 id="status">ProtonFixes is running a task, please wait...</h3>
-    <div class="loader">Loading...</div>
+    <div id="progress-container">
+      <h4 id="progress-text">Loading...</h4>
+      <div id="progress"><div id="progress-bar"></div></div>
+    </div>
+    <script>
+        function setWidth(width){
+            var elem = document.getElementById("progress-bar");
+            if(width > 100) width = 100;
+            elem.style.width = width*0.98 + '%';
+        }
+
+        function setText(text){
+            var elem = document.getElementById("progress-text");
+            elem.innerHTML = text;
+        }
+        setWidth(0);
+    </script>
   </div>
 </body>
 

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -7,12 +7,9 @@ import sys
 import re
 import shutil
 import signal
-import zipfile
 import subprocess
-import urllib.request
 import functools
 from .logger import log
-from . import config
 from .protonmain_compat import protonmain
 from .protonversion import PROTON_VERSION, PROTON_TIMESTAMP
 from .progress import TrackProgress
@@ -632,24 +629,3 @@ def set_dxvk_option(opt, val, cfile='/tmp/protonfixes_dxvk.conf'):
         dxvkopts = fini.read().splitlines(True)
     with open(cfile, 'w') as fdxvk:
         fdxvk.writelines(dxvkopts[1:])
-
-@TrackProgress("Downloading zip from: {}")
-def install_from_zip(url, filename, path=os.getcwd()):
-    """ Install a file from a downloaded zip
-    """
-
-    if filename in os.listdir(path):
-        log.info('File ' + filename + ' found in ' + path)
-        return
-
-    cache_dir = config.cache_dir
-    zip_file_name = os.path.basename(url)
-    zip_file_path = os.path.join(cache_dir, zip_file_name)
-
-    if zip_file_name not in os.listdir(cache_dir):
-        log.info('Downloading ' + filename + ' to ' + zip_file_path)
-        urllib.request.urlretrieve(url, zip_file_path)
-
-    with zipfile.ZipFile(zip_file_path, 'r') as zip_obj:
-        log.info('Extracting ' + filename + ' to ' + path)
-        zip_obj.extract(filename, path=path)

--- a/protonfixes/util.py
+++ b/protonfixes/util.py
@@ -15,6 +15,7 @@ from .logger import log
 from . import config
 from .protonmain_compat import protonmain
 from .protonversion import PROTON_VERSION, PROTON_TIMESTAMP
+from .progress import TrackProgress
 
 # pylint: disable=unreachable
 
@@ -222,6 +223,7 @@ def is_custom_verb(verb):
     return False
 
 
+@TrackProgress("Installing winetrick: {}")
 def protontricks(verb):
     """ Runs winetricks if available
     """
@@ -631,6 +633,7 @@ def set_dxvk_option(opt, val, cfile='/tmp/protonfixes_dxvk.conf'):
     with open(cfile, 'w') as fdxvk:
         fdxvk.writelines(dxvkopts[1:])
 
+@TrackProgress("Downloading zip from: {}")
 def install_from_zip(url, filename, path=os.getcwd()):
     """ Install a file from a downloaded zip
     """


### PR DESCRIPTION
![](https://i.postimg.cc/cHCGd5RL/cef.png)
We have a progress bar :tada:  (should fix #8)

Minor things that have changed:

* `config.ini`: new config options
  * `splash_preference`: order in which splashes are going to be tried
  * `zenity_bigpicture`: allow zenity as splash in bigpicture mode
* `util.install_from_zip` has been moved to download in an effort to slim down utils and since it made more sense to be there
* metal slug fixes and doom have been modified to use `download.install_from_zip`, `install_from_zip` now has a `filesha` parameter like in the metal slug fixes

### How the progress bar works
1. `TrackProgress` is created in `progress.py`, it has an internal registry
2. `fix.py` imports all the modules that have `TrackProgress`-decorated functions, the decorator is invoked and the internal registry is populated with fully-qualified function names that are being decorated (e.g. `protonfixes.utils.protontricks`)
3. When `fix.py` finds a suitable fix, it loads the `.py` file into `progress.parse_fix`, this in turn runs ast (static parsing) and outputs a list of fully-qualified function calls in the specified `.py` file, it then filters out any that are not in the `TrackProgress` registry and sets the `TOTAL_STEPS` variable
4. Once a fix's `main()` is actually called the decorator indirectly calls functions in `splash.py` to update the title and increment the progress bar.
5. `splash` checks which method it used for displaying progress and uses an appropriate way to updated it. (CEF needs a Queue since it runs on a separate process)

