### PR TITLE
 Added fixes for TES V: Skyrim Special Edition

### DIFF
--- a/protonfixes/gamefixes/489830.py
+++ b/protonfixes/gamefixes/489830.py
@@ -1,0 +1,13 @@
+""" Game fix for The Elder Scrolls V: Skyrim Special Edition
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+
+def main():
+    """ Install FAudio for NPC dialog audio
+    """
+
+    # Source: https://github.com/ValveSoftware/Proton/issues/4
+    util.protontricks('faudio')


### PR DESCRIPTION
Installing FAudio is needed for working dialog audio with NPCs.
This was discovered here: https://github.com/ValveSoftware/Proton/issues/4#issuecomment-415748747