### PR TITLE
Fix splash.py in case kivy isn't installed, lint fix

### DIFF
--- a/protonfixes/splash.py
+++ b/protonfixes/splash.py
@@ -30,6 +30,7 @@ try:
     HAS_KIVY = True
 except ImportError:
     HAS_KIVY = False
+    App = object
     log.warn('Optional dependency kivy not found')
 
 
@@ -147,6 +148,9 @@ class SplashApp(App):
         pbar.size = (maxsize * progress, oldsize[1])
 
     def on_start(self):
+        """ This function is run when the splash has finished loading
+            release the started Event to allow progress manipulation
+        """
         self.started.set()
 
 


### PR DESCRIPTION
As the title states this fix will allow to launch protonfixes without kivy (App now is replaced with `object` in case kivy isn't present)

Also added a docstring to `SplashApp.on_start` that was causing a lint error

Closes #121 