### PR TITLE
Add fix for SimpleRockets

### DIFF
--- a/protonfixes/gamefixes/343090.py
+++ b/protonfixes/gamefixes/343090.py
@@ -1,0 +1,13 @@
+""" Game fix for SimpleRockets
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Uses winetricks to install dotnet40
+        https://appdb.winehq.org/objectManager.php?sClass=version&iId=34014
+    """
+
+    # If not already installed, install dotnet40
+    util.protontricks('dotnet40')


### PR DESCRIPTION
SimpleRockets won't start without dotnet40
Fix reported by folks on ProtonDB: https://www.protondb.com/app/343090