### PR TITLE
add fixes for Persona 4 Golden

### DIFF
--- a/protonfixes/gamefixes/1113000.py
+++ b/protonfixes/gamefixes/1113000.py
@@ -1,0 +1,13 @@
+""" Game fix for Persona 4 Golden
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs devenum, quartz, wmp9
+    """
+
+    util.protontricks('devenum')
+    util.protontricks('quartz')
+    util.protontricks('wmp9')

--- a/protonfixes/gamefixes/1113000.py
+++ b/protonfixes/gamefixes/1113000.py
@@ -5,9 +5,13 @@
 from protonfixes import util
 
 def main():
-    """ installs devenum, quartz, wmp9
+    """ installs devenum, quartz, wmp9 and adjust pulse latency
     """
 
+    # Fix pre-rendered cutscene playback
     util.protontricks('devenum')
     util.protontricks('quartz')
     util.protontricks('wmp9')
+
+    # Fix crackling audio
+    util.set_environment('PULSE_LATENCY_MSEC', '60')


### PR DESCRIPTION
Note that this requires a recent version of winetricks (20200412) to install wmp9 in 64-bit prefixes.