### PR TITLE
Improve handling for all ManiaPlanet Titles

### DIFF
--- a/protonfixes/gamefixes/228760.py
+++ b/protonfixes/gamefixes/228760.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/229870.py
+++ b/protonfixes/gamefixes/229870.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/232910.py
+++ b/protonfixes/gamefixes/232910.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/233050.py
+++ b/protonfixes/gamefixes/233050.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/233070.py
+++ b/protonfixes/gamefixes/233070.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/243360.py
+++ b/protonfixes/gamefixes/243360.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/264660.py
+++ b/protonfixes/gamefixes/264660.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/264850.py
+++ b/protonfixes/gamefixes/264850.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/600720.py
+++ b/protonfixes/gamefixes/600720.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")

--- a/protonfixes/gamefixes/600730.py
+++ b/protonfixes/gamefixes/600730.py
@@ -3,33 +3,56 @@
 #pylint: disable=C0103
 
 import os
+import shutil
 from protonfixes import util
 from protonfixes.logger import log
 
-mania_planet_games = [264850, 228760, 232910, 243360, 264660,
-                      600720, 600730, 233070, 229870, 233050]
+mania_planet_games = [228760, 229870, 232910, 233050, 233070,
+                      243360, 264660, 264850, 600720, 600730]
+
 
 def main():
-    """ Create a ManiaPlanet folder in comptdata and link every game_bottle.
+    """ Create a ManiaPlanet folder in compatdata and link the prefixes for every game_bottle.
         With this games ManiaPlanet games can be switched while in game. (Same as in windows now)
     """
 
     game_proton_bottle = os.path.dirname(os.path.dirname(util.protonprefix()))
     compdata_folder = os.path.dirname(game_proton_bottle)
-    mania_planet_folder = os.path.join(compdata_folder, "ManiaPlanet")
+    mania_planet_pfx = os.path.join(compdata_folder, "ManiaPlanet")
 
-    if not os.path.exists(mania_planet_folder):
+    if not os.path.exists(mania_planet_pfx):
         log("Could not find ManiaPlanet directory.")
-        log("Creating new folder and symlinking Games to it.")
-        os.rename(game_proton_bottle, mania_planet_folder)
-        os.symlink(mania_planet_folder, game_proton_bottle)
+        log("Creating new folder and symlinking games to it.")
+        pfx_folder = os.path.join(game_proton_bottle, "pfx")
+        os.rename(pfx_folder, mania_planet_pfx)
+        os.symlink(mania_planet_pfx, pfx_folder)
 
-        for game_id in mania_planet_games:
-            game_path = os.path.join(compdata_folder, str(game_id))
-            if game_path == game_proton_bottle:
-                continue
-            if os.path.exists(game_path):
-                os.remove(game_id)
+    for game_id in mania_planet_games:
+        game_pfx = os.path.join(compdata_folder, str(game_id), "pfx")
+        log("Checking {}".format(game_id))
+        if not os.path.exists(game_pfx):
+            log("No prefix for {} found, skipping.".format(game_id))
+            continue
+        if os.path.islink(game_pfx):
+            log("{} is already a symlink, skipping.".format(game_id))
+            continue
 
-            os.symlink(mania_planet_folder, game_path)
-        log("All DONE")
+        log("Copying contents of {} to ManiaPlanet folder.".format(game_id))
+        for src_dir, dirs, files in os.walk(game_pfx):
+            dst_dir = src_dir.replace(game_pfx, mania_planet_pfx, 1)
+            for file_ in files:
+                src_file = os.path.join(src_dir, file_)
+                dst_file = os.path.join(dst_dir, file_)
+                if os.path.exists(dst_file) or not os.path.exists(src_file):
+                    continue
+                try:
+                    shutil.move(src_file, dst_file)
+                    log("Moving {} to {}".format(src_file, dst_file))
+                except FileNotFoundError:
+                    # FIXME: paths with special chars (&, whitespace) do not work!
+                    log("Can't move {}. Continuing anyway.".format(src_file))
+        log("Removing {}".format(game_pfx))
+        shutil.rmtree(game_pfx)
+        log("Symlinking {} prefix to ManiaPlanet folder.".format(game_id))
+        os.symlink(mania_planet_pfx, game_pfx)
+    log("All DONE")


### PR DESCRIPTION
The previous scripts did not work because of a bug in line 32. It should've been `os.remove(game_path)` instead of `os.remove(game_id)`.
Instead of simply fixing the bug I decided to add some features:
* Only symlink the wine pfx, not the whole bottle
* Try copying everything from the old prefixes into the new prefix (does not yet work for filenames containing special chars like & or whitespace, no clue why)
* Before, only the contents of one game would've been copied and everything else would've been deleted.
* Before, the for loop for deleting and linking all other games had too big indentation, so it would never run anyways.