### PR TITLE
Add fix for Age of Wonders: Planetfall

### DIFF
--- a/protonfixes/gamefixes/718850.py
+++ b/protonfixes/gamefixes/718850.py
@@ -1,0 +1,13 @@
+""" Game fix Age of Wonders: Planetfall
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+
+def main():
+    """ Changes the proton argument from the launcher to the game
+    """
+
+    # Replace launcher with game exe in proton arguments
+    util.replace_command('dowser.exe', 'AowPF.exe')


### PR DESCRIPTION
Start the game instead of the launcher because the launcher crashes.