### PR TITLE
Update 1113000.py (Persona 4 Golden)

### DIFF
--- a/protonfixes/gamefixes/1113000.py
+++ b/protonfixes/gamefixes/1113000.py
@@ -5,13 +5,14 @@
 from protonfixes import util
 
 def main():
-    """ installs devenum, quartz, wmp9 and adjust pulse latency
+    """ installs devenum, quartz, wmp9, lavfilters and adjust pulse latency
     """
 
     # Fix pre-rendered cutscene playback
     util.protontricks('devenum')
     util.protontricks('quartz')
     util.protontricks('wmp9')
+    util.protontricks('lavfilters')
 
     # Fix crackling audio
     util.set_environment('PULSE_LATENCY_MSEC', '60')


### PR DESCRIPTION
Additionally requires lavfilters to work with version 1.1 of the game.

https://www.protondb.com/app/1113000
https://github.com/GloriousEggroll/protonfixes/commit/997a0b4a5d799342e412f420211d43aaeb90af83

The lavfilters verb has been added to winetricks with
https://github.com/Winetricks/winetricks/commit/8b999767e166c16692cfa10dfc7f31f5c13adab9
and is included in the 20201206 release.