### PR TITLE
Fix corefonts.py getting 403

### DIFF
--- a/protonfixes/corefonts.py
+++ b/protonfixes/corefonts.py
@@ -45,7 +45,7 @@ def download_file(url, files):
     """
 
     log.debug('Downloading ' + url)
-    with urllib.request.urlopen(url, files) as font:
+    with urllib.request.urlopen(url) as font:
         with Temp(delete=False, prefix='font' + str(os.getpid())) as temp:
             shutil.copyfileobj(font, temp)
             files.append(temp)


### PR DESCRIPTION
Fixes #147

The second argument to `urlopen` is the data sent to the server. The server doesn't want any data on our local files, so it replies with 403.
After removing the argument, #147 no longer reproduced.