### PR TITLE
Game fix for Toybox Turbos (287260)

### DIFF
--- a/protonfixes/gamefixes/287260.py
+++ b/protonfixes/gamefixes/287260.py
@@ -1,0 +1,15 @@
+""" Game fix for Toybox Turbos
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+
+def main():
+    """ Changes the proton argument from the launcher to the game
+    """
+
+    log('Applying fixes for Toybox Turbos')
+
+    # Fix infinite startup screen
+    util.set_environment('PROTON_NO_ESYNC', '1')


### PR DESCRIPTION
The game has infinite loading screens when esync is not disabled.

I haven't tested this with protonfixes (yet) but setting `PROTON_NO_ESYNC=1` fixed the problem.