### PR TITLE
Fix soldier_protonfixify script

### DIFF
--- a/scripts/soldier_protonfixify
+++ b/scripts/soldier_protonfixify
@@ -7,6 +7,7 @@
 DEBIAN_REPO_BASE="https://deb.debian.org/debian/pool/"
 BASE_DIR="${1}"
 PROTONFIXES_DIR="${2}"
+LOGFILE="/tmp/protonfixify.log"
 
 
 install_debian_package(){
@@ -47,7 +48,7 @@ EOF
                                           --tmpfs /usr --tmpfs /tmp \
                                           --setenv PATH '/bin:/sbin' \
                                           --proc /proc --dev /dev \
-                                          -- /pip-install.sh > /dev/null 2>&1
+                                          -- /pip-install.sh >> ${LOGFILE}
     cp -r "${NEWROOT}/lib/python3.7/site-packages/"* "${1}/soldier/files/lib/python3.7"
     cp -r "${PROTONFIXES_DIR}" "${1}/soldier/files/lib/python3.7"
     rm -r "${NEWROOT}"
@@ -82,6 +83,9 @@ install_zenity(){
 }
 
 
+# Truncate log file (for debugging purposes), send stderr to log
+echo -n '' > ${LOGFILE}
+exec 2>>${LOGFILE}
 # We use run-in-soldier to make sure that the chroot is extracted
 "${BASE_DIR}/run-in-soldier" -- /bin/true > /dev/null 2>&1
 install_python_packages "${BASE_DIR}"

--- a/scripts/soldier_protonfixify
+++ b/scripts/soldier_protonfixify
@@ -58,7 +58,7 @@ EOF
 install_winetricks(){
     # Install winetricks and needed packages in $1
     echo '[PROTONFIXIFY] Installing Winetricks'
-    local WINETRICKS_PACKAGES=("main/u/unzip/unzip_6.0-23+deb10u1_amd64.deb"
+    local WINETRICKS_PACKAGES=("main/u/unzip/unzip_6.0-23+deb10u2_amd64.deb"
                                "main/c/cabextract/cabextract_1.9-1_amd64.deb"
                                "main/libm/libmspack/libmspack0_0.10.1-1_amd64.deb")
 
@@ -77,7 +77,7 @@ install_zenity(){
                            "main/z/zenity/zenity-common_3.30.0-2_all.deb")
 
     for package in "${ZENITY_PACKAGES[@]}"; do
-    install_debian_package "$package" "${1}"
+        install_debian_package "$package" "${1}"
     done
     cp "${PROTONFIXES_DIR}/static/libwebkit2gtk-4.0.so.37" "${1}/lib"
 }

--- a/scripts/soldier_protonfixify
+++ b/scripts/soldier_protonfixify
@@ -7,6 +7,7 @@
 DEBIAN_REPO_BASE="https://deb.debian.org/debian/pool/"
 BASE_DIR="${1}"
 PROTONFIXES_DIR="${2}"
+BUILD_ID="$(cat ${1}/com.valvesoftware.SteamRuntime.Platform-amd64,i386-soldier-buildid.txt)"
 LOGFILE="/tmp/protonfixify.log"
 
 
@@ -32,7 +33,7 @@ install_python_packages(){
     local DISTUITLS_PACKAGE="main/p/python3-stdlib-extensions/python3-distutils_3.7.3-1_all.deb"
 
     local NEWROOT="$(mktemp -d)"
-    cp -rT "${1}/soldier/files" "${NEWROOT}"
+    cp -rT "${2}" "${NEWROOT}"
     install_debian_package "${DISTUITLS_PACKAGE}" "${NEWROOT}"
     cp /etc/resolv.conf "${NEWROOT}/etc/resolv.conf"
     cat <<EOF > "${NEWROOT}/pip-install.sh"
@@ -49,8 +50,8 @@ EOF
                                           --setenv PATH '/bin:/sbin' \
                                           --proc /proc --dev /dev \
                                           -- /pip-install.sh >> ${LOGFILE}
-    cp -r "${NEWROOT}/lib/python3.7/site-packages/"* "${1}/soldier/files/lib/python3.7"
-    cp -r "${PROTONFIXES_DIR}" "${1}/soldier/files/lib/python3.7"
+    cp -r "${NEWROOT}/lib/python3.7/site-packages/"* "${2}/lib/python3.7"
+    cp -r "${PROTONFIXES_DIR}" "${2}/lib/python3.7"
     rm -r "${NEWROOT}"
 }
 
@@ -87,7 +88,15 @@ install_zenity(){
 echo -n '' > ${LOGFILE}
 exec 2>>${LOGFILE}
 # We use run-in-soldier to make sure that the chroot is extracted
-"${BASE_DIR}/run-in-soldier" -- /bin/true > /dev/null 2>&1
-install_python_packages "${BASE_DIR}"
-install_winetricks "${BASE_DIR}/soldier/files"
-install_zenity "${BASE_DIR}/soldier/files"
+"${BASE_DIR}/run-in-soldier" -- /bin/true >> ${LOGFILE}
+# Check for legacy root location in soldier/files
+# Should now be var/deploy-${build_id}/files
+if [ -z "$(ls -A ${BASE_DIR}/soldier)" ]; then
+    ROOT_DIR="${1}/var/deploy-${BUILD_ID}/files"
+else
+    ROOT_DIR="${1}/soldier/files"
+fi
+
+install_python_packages "${BASE_DIR}" "${ROOT_DIR}"
+install_winetricks "${ROOT_DIR}"
+install_zenity "${ROOT_DIR}"

--- a/scripts/soldier_protonfixify
+++ b/scripts/soldier_protonfixify
@@ -3,6 +3,7 @@
 # $1 - the soldier runtime directory, usually steamapps/common/SteamLinuxRuntime_soldier
 # $2 - the protonfixes install directory, needed for now to get the
 #      libwebkit2gtk shim library
+set -euo pipefail
 
 DEBIAN_REPO_BASE="https://deb.debian.org/debian/pool/"
 BASE_DIR="${1}"


### PR DESCRIPTION
Soldier now is installed in a different directory, so the `soldier_protonfixify` script needs to be updated

Contents of this PR:
* saner options for the script, with `set -euo pipefail` for extra robustness
* updated one of the debian dependencies that otherwise would not be downloaded
* Now the script logs errors & major console spams to `/tmp/protonfixify.log` to allow easier debugging
* The install root of soldier has changed location, the script checks for both variations just in case

I don't know if #154 is related, but it would be worth checking if @Zyneris has the same problem after clearing the `.protonfixify` file inside the soldier folder and  rerunning `install_protonfixes`