### PR TITLE
Add game fix for realMyst

### DIFF
--- a/protonfixes/gamefixes/63600.py
+++ b/protonfixes/gamefixes/63600.py
@@ -1,0 +1,14 @@
+""" Game fix for realMyst
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+from protonfixes.logger import log
+
+def main():
+    """ Uses winetricks to install the icodecs verb
+    """
+
+    log('Applying fixes for realMyst')
+
+    util.protontricks('icodecs')


### PR DESCRIPTION
icodecs is necessary to show in-game videos and also fixes framerate issues