### PR TITLE
Added STAR WARS™ Galactic Battlegrounds Saga (356500)

### DIFF
--- a/protonfixes/gamefixes/356500.py
+++ b/protonfixes/gamefixes/356500.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Game fix for STAR WARS™ Galactic Battlegrounds Saga (356500)
+"""
+#pylint: disable=C0103
+
+__updated__ = '2022-03-21 23:09:28'
+
+import pathlib as pl
+
+from protonfixes import util
+
+
+def main():
+    """
+    * Fix GUI issues by using virtual desktop.
+    * Fix multiplayer by installing 'directplay'.
+    * Fix startup by not using the launcher.
+    """
+    # the menu is *always* 800x600 and this setting doesn't affect in game resolution
+    # taken from [here](https://www.protondb.com/app/356500#zKoYYDdEIs)
+    util.protontricks('settings vd=800x600')
+
+    # to fix multiplayer
+    # as of Proton 7.0-1 before 'directplay' can be installed, the existing files need to be removed
+    files_to_remove = set([
+        'dplaysvr.exe', 'dplayx.dll', 'dpnet.dll', 'dpnhpast.dll',
+        'dpnsvr.exe', 'dpwsockx.dll'
+    ])
+    prefix_path = pl.Path(util.protonprefix())
+    lib_path = 'syswow64'
+    if util.win32_prefix_exists():
+        lib_path = 'system32'
+
+    for file_to_remove in files_to_remove:
+        try:
+            (prefix_path / 'drive_c' / 'windows' / lib_path /
+             file_to_remove).unlink()
+        except FileNotFoundError:
+            pass
+    # as of Proton 7.0-1 the verb 'directplay' must be installed to make LAN multiplayer work
+    util.protontricks('directplay')
+
+    # taken from [here](https://www.protondb.com/app/356500#zKoYYDdEIs)
+    util.replace_command('player.exe', 'battlegrounds_x1.exe')


### PR DESCRIPTION
I have based this on [my (tested) gist](https://gist.github.com/nils-ballmann/ce467beaf4d10b8fa3ad54baf1f8933b).

But as [soldier_protonfixify](../blob/b65c42c833e6d046149e5a51ed0f85bc0a16c2b8/scripts/soldier_protonfixify#L11) seems to be broken with (at least) version `0.20220131.0` of soldier I'm not sure how to test. I tried to fix the line 11 by applying this patch
```diff
diff --git a/scripts/soldier_protonfixify b/scripts/soldier_protonfixify
index 53a45ed..4c5f3f3 100755
--- a/scripts/soldier_protonfixify
+++ b/scripts/soldier_protonfixify
@@ -8,7 +8,11 @@ set -euo pipefail
 DEBIAN_REPO_BASE="https://deb.debian.org/debian/pool/"
 BASE_DIR="${1}"
 PROTONFIXES_DIR="${2}"
-BUILD_ID="$(cat ${1}/com.valvesoftware.SteamRuntime.Platform-amd64,i386-soldier-buildid.txt)"
+if [ -f "${1}/com.valvesoftware.SteamRuntime.Platform-amd64,i386-soldier-buildid.txt" ]; then
+    BUILD_ID="$(cat ${1}/com.valvesoftware.SteamRuntime.Platform-amd64,i386-soldier-buildid.txt)"
+else
+    BUILD_ID="$(grep soldier ${1}/VERSIONS.txt | cut -f2)"
+fi
 LOGFILE="/tmp/protonfixify.log"
```
but unfortunately this seems not to be enough.