### PR TITLE
Add compatibility for 684450

### DIFF
--- a/protonfixes/gamefixes/684450.py
+++ b/protonfixes/gamefixes/684450.py
@@ -1,0 +1,10 @@
+""" Game fix for Surviving the Aftermath
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Launcher currently broken
+    """
+    util.replace_command("launcher/Paradox Launcher.exe", "Aftermath64.exe")


### PR DESCRIPTION
This fix bypasses the Paradox launcher to be able to launch Surviving the Aftermath.