### PR TITLE
Added a fix for State of Decay 2 Crashes

### DIFF
--- a/protonfixes/gamefixes/495420.py
+++ b/protonfixes/gamefixes/495420.py
@@ -1,0 +1,13 @@
+""" Game fix for State of Decay 2
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Fix game crashes with d3dcompiler_47 and multiplayer crashes with win7
+    """
+
+    util.protontricks('d3dcompiler_47')
+    util.protontricks('win7')
+


### PR DESCRIPTION
Added `d3dcompiler_47` to prevent game crashes and `win7` to fix multiplayer and prevent multiplayer crashes.